### PR TITLE
Parquet DocValues codec + liquid page cache + zero-copy + decode speedups

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -682,3 +682,78 @@ If you still see a failing test that is not part of the post merge actions, plea
 ### Gradle Check Metrics Dashboard
 
 To get the comprehensive insights and analysis of the Gradle Check test failures, visit the [OpenSearch Gradle Check Metrics Dashboard](https://metrics.opensearch.org/_dashboards/app/dashboards#/view/e5e64d40-ed31-11ee-be99-69d1dbc75083). This dashboard is part of the [OpenSearch Metrics Project](https://github.com/opensearch-project/opensearch-metrics) initiative. The dashboard contains multiple data points that can help investigate and resolve flaky failures. Additionally, this dashboard can be used to drill down, slice, and dice the data using multiple supported filters, which further aids in troubleshooting and resolving issues.
+
+
+## Running the Parquet DocValues Codec (with / without Liquid Cache)
+
+### Prerequisites (toolchain)
+- **JDK 25** 
+- **protoc 3.x** on `PATH`
+- **Linux only** — Liquid is gated `#[cfg(target_os = "linux")]`; build & run on EC2/linux, not Mac.
+- **Rust / cargo ≥ 1.85**
+
+### Build (one-time; ~15–20 min for the native lib)
+```bash
+git checkout bench-codec-liquid-zerocopy   # or a specific commit (see below)
+
+# 1. Native lib (Liquid + zero-copy are Rust)
+cd sandbox/libs/dataformat-native/rust
+cargo build --release -p opensearch-native-lib -j "$(nproc)"
+# → target/release/libopensearch_native.so
+
+# 2. Distro + the ABI-coupled plugins (from repo root)
+cd ~/OpenSearch   # back to repo root
+export JAVA_HOME=<your JDK 25 path>
+./gradlew localDistro -x test -x javadoc -x missingJavadoc
+
+# 3. Deploy fresh core lib + plugins into your run dir (e.g. ~/3.8.0-ARCHIVE)
+ARCHIVE=~/3.8.0-ARCHIVE
+rsync -a build/distribution/local/opensearch-3.8.0-SNAPSHOT/lib/ "$ARCHIVE/lib/"
+~/build.sh plugin parquet-data-format
+~/build.sh plugin analytics-backend-datafusion
+```
+
+Run — LIQUID ON
+
+```
+
+CFG=~/3.8.0-ARCHIVE/config/opensearch.yml
+grep -v -iE "liquid_cache" "$CFG" > "$CFG.tmp" && mv "$CFG.tmp" "$CFG"
+grep -q "pluggable.dataformat.enabled" "$CFG" || echo "opensearch.experimental.feature.pluggable.dataformat.enabled: true" >> "$CFG"
+cat >> "$CFG" <<'YML'
+parquet.liquid_cache.enabled: true
+datafusion.liquid_cache.enabled: true
+datafusion.liquid_cache.cache_dir: /tmp/opensearch/liquid_cache
+YML
+mkdir -p /tmp/opensearch/liquid_cache
+
+pkill -f 'org.opensearch.bootstrap.OpenSearch'; sleep 6
+# Temporary hack (Liquid ON):** must launch with `TMPDIR` on a real disk (`TMPDIR=/home/ec2-user/liquid-tmp`), not tmpfs — else Liquid's t4 store mmap fails and panics the codec. # Workaround until the codec mounts its own on-disk cache dir.
+
+TMPDIR=/home/ec2-user/liquid-tmp OPENSEARCH_TMPDIR=/home/ec2-user/liquid-tmp \
+  nohup ~/3.8.0-ARCHIVE/bin/opensearch > ~/os.log 2>&1 &
+until curl -s localhost:9200/_cluster/health | grep -q '"status":"green"'; do sleep 5; echo waiting; done; echo GREEN
+
+# verify liquid is serving (HIT count climbs after a query)
+curl -s "localhost:9200/clickbench/_search?request_cache=false" -H 'Content-Type: application/json' \
+  -d '{"size":0,"aggs":{"a":{"avg":{"field":"UserID"}}}}' >/dev/null
+grep -c "PARQUET_DV_LIQUID.*HIT" ~/3.8.0-ARCHIVE/logs/doc-values-codec.log
+```
+
+Run — LIQUID OFF (plain codec)
+
+```
+CFG=~/3.8.0-ARCHIVE/config/opensearch.yml
+grep -v -iE "liquid_cache" "$CFG" > "$CFG.tmp" && mv "$CFG.tmp" "$CFG"
+grep -q "pluggable.dataformat.enabled" "$CFG" || echo "opensearch.experimental.feature.pluggable.dataformat.enabled: true" >> "$CFG"
+
+# Temporary hack (Liquid ON):** must launch with `TMPDIR` on a real disk (`TMPDIR=/home/ec2-user/liquid-tmp`), not tmpfs — else Liquid's t4 store mmap fails and panics the codec. # Workaround until the codec mounts its own on-disk cache dir.
+pkill -f 'org.opensearch.bootstrap.OpenSearch'; sleep 6
+TMPDIR=/home/ec2-user/liquid-tmp nohup ~/3.8.0-ARCHIVE/bin/opensearch > ~/os.log 2>&1 &
+until curl -s localhost:9200/_cluster/health | grep -q '"status":"green"'; do sleep 5; echo waiting; done; echo GREEN
+
+# verify OFF: HIT count stays flat after a query
+curl -s "localhost:9200/clickbench/_search?request_cache=false" -H 'Content-Type: application/json' \
+  -d '{"size":0,"aggs":{"a":{"avg":{"field":"UserID"}}}}' >/dev/null
+grep -c "PARQUET_DV_LIQUID.*HIT" ~/3.8.0-ARCHIVE/logs/doc-values-codec.log
+```

--- a/sandbox/libs/dataformat-native/rust/Cargo.lock
+++ b/sandbox/libs/dataformat-native/rust/Cargo.lock
@@ -3247,6 +3247,7 @@ dependencies = [
  "crc32fast",
  "dashmap 5.5.3",
  "lazy_static",
+ "liquid-cache",
  "native-bridge-common",
  "opensearch-parquet-format",
  "parquet",

--- a/sandbox/libs/dataformat-native/rust/Cargo.lock
+++ b/sandbox/libs/dataformat-native/rust/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
 dependencies = [
  "object",
 ]
@@ -217,6 +217,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-flight"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+ "base64",
+ "bytes",
+ "futures",
+ "once_cell",
+ "paste",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "arrow-ipc"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,7 +274,7 @@ dependencies = [
  "arrow-select",
  "chrono",
  "half",
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -290,6 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags",
+ "serde",
  "serde_core",
  "serde_json",
 ]
@@ -349,6 +378,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +430,49 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
@@ -431,9 +525,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake2"
@@ -469,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -538,9 +632,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -685,6 +779,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "congee"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72819224a9c43e0a5d64bdad35a71fde68bf479992fb8989635c72bc547909be"
+dependencies = [
+ "crossbeam-epoch",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +812,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "const_for"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c50fcfdf972929aff202c16b80086aa3cfc6a3a820af714096c58c7c1d0582"
 
 [[package]]
 name = "constant_time_eq"
@@ -742,6 +851,12 @@ dependencies = [
  "num_cpus",
  "winapi",
 ]
+
+[[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "cpufeatures"
@@ -806,6 +921,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -945,7 +1069,7 @@ dependencies = [
  "datafusion-sql",
  "flate2",
  "futures",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "liblzma",
  "log",
@@ -1021,7 +1145,7 @@ dependencies = [
  "foldhash 0.2.0",
  "half",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "log",
@@ -1226,7 +1350,7 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "recursive",
  "serde_json",
@@ -1241,7 +1365,7 @@ checksum = "0225491839a31b1f7d2cb8092c2d50792e2fe1c1724e4e6d08e011f5feaf4ed2"
 dependencies = [
  "arrow",
  "datafusion-common",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
 ]
 
@@ -1401,7 +1525,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "recursive",
@@ -1423,7 +1547,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
  "petgraph",
@@ -1457,7 +1581,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
  "pin-project",
@@ -1506,7 +1630,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "num-traits",
@@ -1557,7 +1681,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions-nested",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "recursive",
  "regex",
@@ -1601,7 +1725,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
 ]
@@ -1664,6 +1788,46 @@ checksum = "2e825441bfb2d831c47c97d05821552db8832479f44c571b97fededbf0099c07"
 dependencies = [
  "small_ctor",
  "web-time",
+]
+
+[[package]]
+name = "fastlanes"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9272a674b446f53253f66582596614e41552d14968a3d1aaa590576a91c1188"
+dependencies = [
+ "const_for",
+ "core_detect",
+ "num-traits",
+ "paste",
+ "seq-macro",
+]
+
+[[package]]
+name = "fastrace"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2130caec636d7a1d23b173576674ced1af967228642ceaeb6a1b4705c282b00e"
+dependencies = [
+ "fastant",
+ "fastrace-macro",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.4",
+ "rtrb",
+ "serde",
+]
+
+[[package]]
+name = "fastrace-macro"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b35f67e02527fca6515ff61f922360df781f477daf6a806fff16bd59525dee5"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1854,6 +2018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsst-rs"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b13ac798afc0d9194eb4efefef8b9332efbd80b43f302a968cb8cb23b9d5360"
+dependencies = [
+ "rustc-hash",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,7 +2183,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2028,6 +2201,12 @@ dependencies = [
  "num-traits",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2086,9 +2265,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2124,6 +2303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2337,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2172,6 +2358,19 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -2333,6 +2532,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -2413,13 +2622,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2550,6 +2758,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "liquid-cache"
+version = "0.1.13"
+source = "git+https://github.com/cocosz/liquid-cache?branch=lc-opensearch-df54-v2#8311bccc258756127adbebee3e54140b60fc09ba"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-schema",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "congee",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "fastlanes",
+ "fastrace",
+ "fsst-rs",
+ "futures",
+ "liquid-cache-common",
+ "log",
+ "num-traits",
+ "object_store",
+ "parquet",
+ "parquet-variant-compute",
+ "serde",
+ "sysinfo",
+ "t4",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "liquid-cache-common"
+version = "0.1.13"
+source = "git+https://github.com/cocosz/liquid-cache?branch=lc-opensearch-df54-v2#8311bccc258756127adbebee3e54140b60fc09ba"
+dependencies = [
+ "arrow-flight",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "object_store",
+ "prost",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "liquid-cache-datafusion"
+version = "0.1.13"
+source = "git+https://github.com/cocosz/liquid-cache?branch=lc-opensearch-df54-v2#8311bccc258756127adbebee3e54140b60fc09ba"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-schema",
+ "bytes",
+ "datafusion",
+ "fastrace",
+ "futures",
+ "liquid-cache",
+ "liquid-cache-common",
+ "log",
+ "object_store",
+ "parquet",
+ "parquet-variant-json",
+ "serde_json",
+ "t4",
+ "tokio",
+]
+
+[[package]]
+name = "liquid-cache-datafusion-local"
+version = "0.1.13"
+source = "git+https://github.com/cocosz/liquid-cache?branch=lc-opensearch-df54-v2#8311bccc258756127adbebee3e54140b60fc09ba"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "datafusion",
+ "fastrace",
+ "liquid-cache",
+ "liquid-cache-common",
+ "liquid-cache-datafusion",
+ "t4",
+ "tokio",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -2647,6 +2951,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2689,6 +2999,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 name = "native-bridge-common"
 version = "0.1.0"
 dependencies = [
+ "log",
  "native-bridge-macros",
  "tikv-jemalloc-ctl",
  "tikv-jemalloc-sys",
@@ -2703,6 +3014,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2751,6 +3071,25 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2855,6 +3194,8 @@ dependencies = [
  "futures",
  "jsonpath-rust",
  "libc",
+ "liquid-cache-datafusion",
+ "liquid-cache-datafusion-local",
  "log",
  "native-bridge-common",
  "num_cpus",
@@ -3039,6 +3380,9 @@ dependencies = [
  "num-integer",
  "num-traits",
  "object_store",
+ "parquet-variant",
+ "parquet-variant-compute",
+ "parquet-variant-json",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -3047,6 +3391,53 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "parquet-variant"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c8db065291f088a2aad8ab831853eae1871c0d311c8d0b83bbc3b7e735d0fc"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.14.0",
+ "num-traits",
+ "simdutf8",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-compute"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a530e8d5b5e14efcb39c9a6ec55432ad11f6afb7dc4455a79be0dc615fe3cc31"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.14.0",
+ "parquet-variant",
+ "parquet-variant-json",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-json"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00ed89908289f67caa2ca078f9ff9aacd6229a313ec92b12bf4f48f613dc2b97"
+dependencies = [
+ "arrow-schema",
+ "base64",
+ "chrono",
+ "parquet-variant",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -3149,7 +3540,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -3260,6 +3651,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3319,9 +3732,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3600,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "regress"
@@ -3679,6 +4092,12 @@ dependencies = [
  "bytemuck",
  "byteorder",
 ]
+
+[[package]]
+name = "rtrb"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
 
 [[package]]
 name = "rustc-hash"
@@ -3913,7 +4332,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3951,7 +4370,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4039,9 +4458,9 @@ checksum = "88414a5ca1f85d82cc34471e975f0f74f6aa54c40f062efa42c0080e7f763f81"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snap"
@@ -4107,7 +4526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e620ff4d5c02fd6f7752931aa74b16a26af66a63022cc1ad412c77edbe0bab47"
 dependencies = [
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "pbjson",
  "pbjson-build",
  "pbjson-types",
@@ -4161,6 +4580,44 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
+name = "t4"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3105026c5fb7e1dcf8864c2193387439aa650b690e1a5513ab27ae7de7999a9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "futures-util",
+ "io-uring",
+ "libc",
+ "t4-verified",
+ "vstd",
+]
+
+[[package]]
+name = "t4-verified"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494c2f2c4cfb21784ef9b380c378fbfdbbe2f19f1ad606e6729816ea2a0f4297"
+dependencies = [
+ "vstd",
 ]
 
 [[package]]
@@ -4378,6 +4835,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4385,11 +4882,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4589,9 +5090,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4603,6 +5104,70 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "verus_builtin"
+version = "0.0.0-2026-05-06-1803"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650bcc71ef90cbc79bc2a2494c54dd159edad63a72677be791954edc993883fe"
+
+[[package]]
+name = "verus_builtin_macros"
+version = "0.0.0-2026-05-10-0145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef946d78c84f284991d59035ca252f29cd8071526003e794be80f0beee18f2d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+ "verus_prettyplease",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_prettyplease"
+version = "0.0.0-2026-05-10-0145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a227e7eaa03f51ac4d659641192bc1b9fe4eda0a509a6734752cf72f5d7daaf"
+dependencies = [
+ "proc-macro2",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_state_machines_macros"
+version = "0.0.0-2026-05-10-0145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff46046bffd2d55757503feef0b72a74a60ead2b58aa211861267485b955136"
+dependencies = [
+ "indexmap 1.9.3",
+ "proc-macro2",
+ "quote",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_syn"
+version = "0.0.0-2026-05-10-0145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82174e474e1f06418dd304f714785ae1c3e4d2fbff415a0d0c05a02cd995819"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "vstd"
+version = "0.0.0-2026-05-10-0145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6958222eaf7bbe565c93890676bb1f96c4f5e25d90a81bb9993fdc19fc0d3f72"
+dependencies = [
+ "verus_builtin",
+ "verus_builtin_macros",
+ "verus_state_machines_macros",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -4640,9 +5205,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -4658,9 +5223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4671,9 +5236,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4681,9 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4691,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4704,9 +5269,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -4728,7 +5293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4754,15 +5319,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4810,6 +5375,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4820,6 +5406,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4849,6 +5446,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -4935,6 +5542,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5067,7 +5683,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5098,7 +5714,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5117,7 +5733,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5158,18 +5774,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5199,9 +5815,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/sandbox/libs/dataformat-native/rust/Cargo.toml
+++ b/sandbox/libs/dataformat-native/rust/Cargo.toml
@@ -75,6 +75,11 @@ criterion = { version = "=0.5.1", features = ["async_tokio"] }
 tokio-metrics = { version = "=0.5.0", features = ["rt"] }
 proptest = "=1.4.0"
 
+# Liquid Cache for byte-level caching
+liquid-cache-datafusion-local = { git = "https://github.com/cocosz/liquid-cache", branch = "lc-opensearch-df54-v2", package = "liquid-cache-datafusion-local" }
+liquid-cache-datafusion = { git = "https://github.com/cocosz/liquid-cache", branch = "lc-opensearch-df54-v2", package = "liquid-cache-datafusion" }
+liquid-cache = { git = "https://github.com/cocosz/liquid-cache", branch = "lc-opensearch-df54-v2", package = "liquid-cache" }
+
 # Internal
 native-bridge-common = { path = "common" }
 opensearch-tiered-storage = { path = "../../tiered-storage/src/main/rust" }
@@ -85,7 +90,7 @@ opensearch-repository-fs = { path = "../../../plugins/native-repository-fs/src/m
 
 [profile.release]
 lto = true
-codegen-units = 1
+codegen-units = 8
 incremental = true
 debug = "line-tables-only"
 strip = false

--- a/sandbox/libs/dataformat-native/rust/common/Cargo.toml
+++ b/sandbox/libs/dataformat-native/rust/common/Cargo.toml
@@ -13,6 +13,7 @@ native-bridge-macros = { path = "../macros" }
 tikv-jemalloc-ctl = { workspace = true }
 tikv-jemalloc-sys = { workspace = true }
 tokio = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
 tikv-jemallocator = { workspace = true }

--- a/sandbox/libs/dataformat-native/rust/common/src/logger.rs
+++ b/sandbox/libs/dataformat-native/rust/common/src/logger.rs
@@ -49,10 +49,42 @@ pub extern "C" fn native_logger_set_level(level: i32) {
     MAX_LEVEL.store(clamped, Ordering::Relaxed);
 }
 
+/// A `log` crate backend that forwards to our native bridge callback.
+/// This makes `log::info!()` from any crate (including liquid-cache)
+/// appear in OpenSearch's log file via the Java RustLoggerBridge.
+struct NativeBridgeLogger;
+
+impl ::log::Log for NativeBridgeLogger {
+    fn enabled(&self, metadata: &::log::Metadata) -> bool {
+        metadata.level() <= ::log::Level::Info
+    }
+
+    fn log(&self, record: &::log::Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let level = match record.level() {
+            ::log::Level::Error => LogLevel::Error,
+            ::log::Level::Warn | ::log::Level::Info => LogLevel::Info,
+            _ => LogLevel::Debug,
+        };
+        let msg = format!("{}", record.args());
+        log(level, &msg);
+    }
+
+    fn flush(&self) {}
+}
+
+static NATIVE_BRIDGE_LOGGER: NativeBridgeLogger = NativeBridgeLogger;
+
 /// Called by Java at startup to register the log callback.
 #[no_mangle]
 pub unsafe extern "C" fn native_logger_init(callback: LogCallback) {
     LOG_CALLBACK.store(callback as *mut (), Ordering::Release);
+    // Initialize the `log` crate facade so that log::info!() from any
+    // dependency (e.g. liquid-cache) routes through our native bridge.
+    let _ = ::log::set_logger(&NATIVE_BRIDGE_LOGGER);
+    ::log::set_max_level(::log::LevelFilter::Info);
     log(LogLevel::Info, "Native logger initialized successfully");
 }
 

--- a/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/NativeCall.java
+++ b/sandbox/libs/dataformat-native/src/main/java/org/opensearch/nativebridge/spi/NativeCall.java
@@ -268,6 +268,40 @@ public final class NativeCall implements AutoCloseable {
         }
     }
 
+    /**
+     * Invoke a {@code long}-returning MethodHandle on caller-owned arguments and check the
+     * result, without allocating an Arena. Use when all native arguments (segments, scalars)
+     * are owned by the caller — e.g. the column-reader hot path, where scratch buffers come
+     * from a pool. A {@code < 0} result is converted to an {@link IOException}; {@code >= 0}
+     * (including positive status codes) is returned as-is.
+     */
+    public static long invokeIOStatic(MethodHandle handle, Object... args) throws IOException {
+        try {
+            long result = (long) handle.invokeWithArguments(args);
+            return NativeLibraryLoader.checkResultIO(result);
+        } catch (IOException | RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new IOException(t);
+        }
+    }
+
+    /**
+     * Invoke a {@code long}-returning MethodHandle on caller-owned arguments and check the
+     * result, without allocating an Arena. A {@code < 0} result is converted to a
+     * {@link RuntimeException}; {@code >= 0} is returned as-is.
+     */
+    public static long invokeStatic(MethodHandle handle, Object... args) {
+        try {
+            long result = (long) handle.invokeWithArguments(args);
+            return NativeLibraryLoader.checkResult(result);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
     @Override
     public void close() {
         closed = true;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/Cargo.toml
@@ -95,6 +95,11 @@ crc32fast = { workspace = true }
 # rewrite. STANDARD alphabet matches the OpenSearch `binary` field wire contract.
 base64 = "0.22"
 
+# Liquid Cache for byte-level caching (experimental, requires io-uring — Linux only)
+[target.'cfg(target_os = "linux")'.dependencies]
+liquid-cache-datafusion-local = { workspace = true }
+liquid-cache-datafusion = { workspace = true }
+
 [dev-dependencies]
 criterion = { workspace = true }
 tempfile = { workspace = true }

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/api.rs
@@ -271,6 +271,7 @@ pub struct DataFusionRuntime {
     pub runtime_env: datafusion::execution::runtime_env::RuntimeEnv,
     pub custom_cache_manager: Option<CustomCacheManager>,
     pub dynamic_limit_handle: DynamicLimitHandle,
+    pub liquid_cache_optimizer: Option<Arc<dyn datafusion::physical_optimizer::PhysicalOptimizerRule + Send + Sync>>,
 }
 
 /// Per-file metadata passed from Java at shard view creation time.
@@ -375,7 +376,22 @@ impl DataFusionRuntime {
             runtime_env,
             custom_cache_manager: None,
             dynamic_limit_handle: handle,
+            liquid_cache_optimizer: None,
         }
+    }
+
+    pub fn apply_liquid_cache_optimizers(
+        &self,
+        mut builder: SessionStateBuilder,
+    ) -> SessionStateBuilder {
+        if let Some(ref optimizer) = self.liquid_cache_optimizer {
+            builder = builder.with_physical_optimizer_rule(optimizer.clone());
+        }
+        builder
+    }
+
+    pub fn has_liquid_cache(&self) -> bool {
+        self.liquid_cache_optimizer.is_some()
     }
 }
 
@@ -469,6 +485,12 @@ pub fn create_global_runtime(
     cache_manager_ptr: i64,
     spill_dir: &str,
     spill_limit: i64,
+    liquid_cache_enabled: bool,
+    liquid_cache_size: i64,
+    liquid_cache_max_disk_bytes: i64,
+    liquid_cache_dir: &str,
+    liquid_cache_eviction_policy: &str,
+    tokio_handle: &tokio::runtime::Handle,
 ) -> Result<i64, DataFusionError> {
     if memory_pool_limit < 0 {
         return Err(DataFusionError::Configuration(format!(
@@ -663,7 +685,30 @@ pub fn create_global_runtime(
         .with_cache_manager(cache_manager_config)
         .build()?;
 
-    let runtime = DataFusionRuntime { runtime_env, custom_cache_manager, dynamic_limit_handle };
+    let liquid_cache_optimizer = if liquid_cache_enabled {
+        #[cfg(target_os = "linux")]
+        {
+            let liquid_runtime = crate::liquid_cache::LiquidOnlyRuntime::init(
+                liquid_cache_size as u64,
+                liquid_cache_max_disk_bytes as u64,
+                liquid_cache_dir,
+                liquid_cache_eviction_policy,
+                tokio_handle,
+            )?;
+            Some(liquid_runtime.optimizer())
+        }
+        #[cfg(not(target_os = "linux"))]
+        { None }
+    } else {
+        None
+    };
+
+    let runtime = DataFusionRuntime {
+        runtime_env,
+        custom_cache_manager,
+        dynamic_limit_handle,
+        liquid_cache_optimizer,
+    };
     Ok(Box::into_raw(Box::new(runtime)) as i64)
 }
 
@@ -1385,6 +1430,21 @@ pub unsafe fn stream_close(stream_ptr: i64) {
 /// No-op for unknown or already-completed queries.
 pub fn cancel_query(context_id: i64) {
     query_tracker::cancel_query(context_id);
+}
+
+/// Clears all caching layers: Liquid Cache (in-memory index + disk) and
+/// DataFusion metadata caches (parquet footers + column statistics).
+pub unsafe fn clear_liquid_cache(runtime_ptr: i64) {
+    #[cfg(target_os = "linux")]
+    crate::liquid_cache::LiquidOnlyRuntime::reset_cache_if_initialized();
+
+    if runtime_ptr == 0 {
+        return;
+    }
+    let runtime = &*(runtime_ptr as *const DataFusionRuntime);
+    if let Some(ref cache_manager) = runtime.custom_cache_manager {
+        cache_manager.clear_all();
+    }
 }
 
 /// Converts SQL to Substrait plan bytes (test only).

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/ffm.rs
@@ -149,11 +149,33 @@ pub unsafe extern "C" fn df_create_global_runtime(
     spill_dir_ptr: *const u8,
     spill_dir_len: i64,
     spill_limit: i64,
+    liquid_cache_enabled: i64,
+    liquid_cache_size: i64,
+    liquid_cache_max_disk_bytes: i64,
+    liquid_cache_mode_ptr: *const u8,
+    liquid_cache_mode_len: i64,
+    liquid_cache_eviction_policy_ptr: *const u8,
+    liquid_cache_eviction_policy_len: i64,
 ) -> i64 {
     crate::memory_guard::set_pool_limit_for_guard(memory_pool_limit);
     let spill_dir = str_from_raw(spill_dir_ptr, spill_dir_len)
         .map_err(|e| format!("df_create_global_runtime: {}", e))?;
-    api::create_global_runtime(memory_pool_limit, cache_manager_ptr, spill_dir, spill_limit)
+    let liquid_cache_dir = str_from_raw(liquid_cache_mode_ptr, liquid_cache_mode_len)
+        .map_err(|e| format!("df_create_global_runtime: liquid_cache_dir: {}", e))?;
+    let liquid_cache_eviction_policy = str_from_raw(liquid_cache_eviction_policy_ptr, liquid_cache_eviction_policy_len)
+        .map_err(|e| format!("df_create_global_runtime: liquid_cache_eviction_policy: {}", e))?;
+    api::create_global_runtime(
+        memory_pool_limit,
+        cache_manager_ptr,
+        spill_dir,
+        spill_limit,
+        liquid_cache_enabled != 0,
+        liquid_cache_size,
+        liquid_cache_max_disk_bytes,
+        liquid_cache_dir,
+        liquid_cache_eviction_policy,
+        get_rt_manager()?.io_runtime.handle(),
+    )
         .map_err(|e| e.to_string())
 }
 
@@ -161,6 +183,70 @@ pub unsafe extern "C" fn df_create_global_runtime(
 pub unsafe extern "C" fn df_close_global_runtime(ptr: i64) {
     api::close_global_runtime(ptr);
 }
+
+// ---- Liquid Cache FFM entry points (Linux only — requires io-uring) ----
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn df_clear_liquid_cache(runtime_ptr: i64) {
+    api::clear_liquid_cache(runtime_ptr);
+}
+#[cfg(not(target_os = "linux"))]
+#[no_mangle]
+pub unsafe extern "C" fn df_clear_liquid_cache(_runtime_ptr: i64) {}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_enabled(enabled: i64) {
+    crate::liquid_cache::LiquidOnlyRuntime::set_enabled_globally(enabled != 0);
+}
+#[cfg(not(target_os = "linux"))]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_enabled(_enabled: i64) {}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_memory_limit(bytes: i64) {
+    if bytes >= 0 {
+        crate::liquid_cache::LiquidOnlyRuntime::set_max_memory_bytes_globally(bytes as usize);
+    }
+}
+#[cfg(not(target_os = "linux"))]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_memory_limit(_bytes: i64) {}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_disk_limit(bytes: i64) {
+    if bytes >= 0 {
+        crate::liquid_cache::LiquidOnlyRuntime::set_max_disk_bytes_globally(bytes as usize);
+    }
+}
+#[cfg(not(target_os = "linux"))]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_disk_limit(_bytes: i64) {}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_selectivity_threshold(permille: i64) {
+    if permille >= 0 && permille <= 1000 {
+        crate::liquid_cache::set_lc_selectivity_threshold(permille as f64 / 1000.0);
+    }
+}
+#[cfg(not(target_os = "linux"))]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_selectivity_threshold(_permille: i64) {}
+
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_max_columns(count: i64) {
+    if count > 0 {
+        crate::liquid_cache::set_lc_max_columns(count as usize);
+    }
+}
+#[cfg(not(target_os = "linux"))]
+#[no_mangle]
+pub extern "C" fn df_set_liquid_cache_max_columns(_count: i64) {}
 
 // ---- Memory pool observability and dynamic limit ----
 
@@ -457,6 +543,8 @@ pub unsafe extern "C" fn df_stream_next(stream_ptr: i64) -> i64 {
 #[no_mangle]
 pub unsafe extern "C" fn df_stream_close(stream_ptr: i64) {
     api::stream_close(stream_ptr);
+    #[cfg(target_os = "linux")]
+    crate::liquid_cache::LiquidOnlyRuntime::log_stats_if_initialized();
 }
 
 /// Returns execution metrics as JSON bytes for the given stream.

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/parquet_bridge.rs
@@ -46,6 +46,7 @@ use datafusion_datasource::source::DataSourceExec;
 use datafusion_datasource::PartitionedFile;
 use futures::future::BoxFuture;
 use futures::FutureExt;
+use native_bridge_common::{log_debug, log_info};
 use object_store::{ObjectStore, ObjectStoreExt};
 use prost::bytes::Bytes;
 
@@ -173,20 +174,27 @@ pub struct RowGroupStreamConfig {
     pub io_stats: Arc<ReadIoStats>,
 }
 
+
 /// Create a stream that reads a single row group using `RowSelection`.
 ///
 /// Predicate pushdown IS safe here — `RowSelection` is applied during decode,
 /// so the predicate sees only selected rows and indices stay aligned.
+///
+/// `selectivity` is the fraction of rows in this RG that are candidates
+/// (0.0 = no rows, 1.0 = all rows). Used to gate LC: highly selective
+/// queries (low selectivity) benefit from LC's column-by-column decode
+/// with filter pushdown.
 pub fn create_row_selection_stream(
     config: &RowGroupStreamConfig,
     rg_index: usize,
     selection: RowSelection,
     push_predicate: bool,
+    selectivity: f64,
 ) -> Result<(SendableRecordBatchStream, Arc<dyn ExecutionPlan>)> {
     let num_rgs = config.metadata.num_row_groups();
     let mut access_plan = ParquetAccessPlan::new_none(num_rgs);
     access_plan.set(rg_index, RowGroupAccess::Selection(selection));
-    create_stream_with_access_plan(config, access_plan, push_predicate)
+    create_stream_with_access_plan(config, access_plan, push_predicate, selectivity)
 }
 
 /// Create a stream that reads a single row group with full scan.
@@ -199,32 +207,16 @@ pub fn create_full_scan_stream(
 ) -> Result<(SendableRecordBatchStream, Arc<dyn ExecutionPlan>)> {
     let num_rgs = config.metadata.num_row_groups();
     let mut access_plan = ParquetAccessPlan::new_none(num_rgs);
-    // TODO(page-boundary-selection): replace `Scan` with a `Selection` built
-    // from the caller's candidate bitmap at page boundaries. The idea:
-    //   - Read the RG's `offset_index` to get per-page row counts.
-    //   - For each page, select if any candidate bit falls within its row
-    //     range, else skip.
-    //   - Pass the resulting `RowSelection` via
-    //     `RowGroupAccess::Selection(selection)`.
-    // This keeps the selector Vec small (O(pages), not O(rows)) regardless of
-    // candidate density, while letting parquet skip whole pages whose row
-    // ranges are entirely outside the candidate set. Bigger I/O savings than
-    // today's full-scan for dense-but-clustered matches, and cheap to build
-    // for any selectivity — unifying today's split between `RowSelection`
-    // strategy (<3%) and `BooleanMask` strategy (≥3%).
-    //
-    // Before implementing, verify parquet-rs's `Selection` delivery
-    // semantics (does it deliver contiguous packed rows or original-position
-    // rows with gaps?) so the caller's post-decode mask alignment stays
-    // correct. Documented in `pr-reviews/EVALUATOR_HANDOFF.md`.
     access_plan.set(rg_index, RowGroupAccess::Scan);
-    create_stream_with_access_plan(config, access_plan, false)
+    // Full scan = selectivity 1.0 (all rows).
+    create_stream_with_access_plan(config, access_plan, false, 1.0)
 }
 
 fn create_stream_with_access_plan(
     config: &RowGroupStreamConfig,
     access_plan: ParquetAccessPlan,
     push_predicate: bool,
+    selectivity: f64,
 ) -> Result<(SendableRecordBatchStream, Arc<dyn ExecutionPlan>)> {
     let partitioned_file = PartitionedFile::new(config.file_path.clone(), config.file_size)
         .with_extensions(Arc::new(access_plan));
@@ -235,24 +227,125 @@ fn create_stream_with_access_plan(
         Arc::clone(&config.io_stats),
     )) as Arc<dyn ParquetFileReaderFactory>;
 
-    let mut parquet_source = ParquetSource::new(config.full_schema.clone())
+    let parquet_source = ParquetSource::new(config.full_schema.clone())
         .with_parquet_file_reader_factory(reader_factory)
         // cannot use page index because we have collector bitset matches that are not visible
         // with just parquet predicates
         .with_enable_page_index(false);
 
-    if push_predicate {
-        if let Some(ref pred) = config.predicate {
-            parquet_source = parquet_source
-                .with_predicate(Arc::clone(pred))
-                .with_pushdown_filters(true)
-                .with_reorder_filters(true);
-        }
-    }
+    // Liquid Cache wraps the CLEAN source (no predicate) so it acts as a pure
+    // decoded-batch cache without filter pushdown. The BoolNode evaluator handles
+    // all filtering externally. When LC is disabled, fall through to the standard
+    // path which may apply predicate pushdown.
+    // LC engagement (Linux only — requires io-uring): wrap when ALL projected
+    // columns are cacheable (numeric/date/timestamp/boolean) and no predicate
+    // column is string. The opener decides per-file whether to STREAM or DELEGATE.
+    #[cfg(target_os = "linux")]
+    let use_lc = {
+        let lc_globally_enabled = crate::liquid_cache::LiquidOnlyRuntime::is_enabled_globally();
+        let max_cols = crate::liquid_cache::lc_max_columns();
+        let all_numeric_projection = config.projection.as_ref().map_or(false, |proj| {
+            !proj.is_empty() && proj.len() <= max_cols && proj.iter().all(|&idx| {
+                config.full_schema.fields().get(idx).map_or(false, |f| {
+                    f.data_type().is_numeric()
+                        || matches!(f.data_type(),
+                            datafusion::arrow::datatypes::DataType::Date32
+                            | datafusion::arrow::datatypes::DataType::Date64
+                            | datafusion::arrow::datatypes::DataType::Timestamp(_, _)
+                            | datafusion::arrow::datatypes::DataType::Boolean
+                        )
+                })
+            })
+        });
+        let predicate_has_string = config.predicate.as_ref().map_or(false, |pred| {
+            let referenced = datafusion::physical_expr::utils::collect_columns(pred);
+            referenced.iter().any(|col| {
+                config.full_schema.fields().get(col.index()).map_or(false, |f| {
+                    matches!(
+                        f.data_type(),
+                        datafusion::arrow::datatypes::DataType::Utf8
+                            | datafusion::arrow::datatypes::DataType::Utf8View
+                            | datafusion::arrow::datatypes::DataType::LargeUtf8
+                            | datafusion::arrow::datatypes::DataType::Binary
+                            | datafusion::arrow::datatypes::DataType::BinaryView
+                            | datafusion::arrow::datatypes::DataType::LargeBinary
+                    )
+                })
+            })
+        });
+        let result = lc_globally_enabled && all_numeric_projection && !predicate_has_string;
+        log_debug!(
+            "[parquet_bridge] gate: selectivity={:.3}, all_numeric_proj={}, pred_has_string={}, use_lc={}",
+            selectivity, all_numeric_projection, predicate_has_string, result,
+        );
+        result
+    };
+    #[cfg(not(target_os = "linux"))]
+    let use_lc = false;
 
-    let mut config_builder =
-        FileScanConfigBuilder::new(config.store_url.clone(), Arc::new(parquet_source))
-            .with_file(partitioned_file);
+    #[cfg(target_os = "linux")]
+    let config_builder = if use_lc {
+        if let Some(cache_ref) = crate::liquid_cache::LiquidOnlyRuntime::cache_ref_globally() {
+            let mut source = parquet_source;
+            if push_predicate {
+                if let Some(ref pred) = config.predicate {
+                    source = source
+                        .with_predicate(Arc::clone(pred))
+                        .with_pushdown_filters(true)
+                        .with_reorder_filters(true);
+                }
+            }
+            let liquid_source = liquid_cache_datafusion::LiquidParquetSource::from_parquet_source(
+                source,
+                cache_ref,
+            );
+            FileScanConfigBuilder::new(config.store_url.clone(), Arc::new(liquid_source))
+                .with_file(partitioned_file)
+        } else {
+            let mut source = parquet_source;
+            if push_predicate {
+                if let Some(ref pred) = config.predicate {
+                    source = source
+                        .with_predicate(Arc::clone(pred))
+                        .with_pushdown_filters(true)
+                        .with_reorder_filters(true);
+                }
+            }
+            FileScanConfigBuilder::new(config.store_url.clone(), Arc::new(source))
+                .with_file(partitioned_file)
+        }
+    } else {
+        let mut source = parquet_source;
+        if push_predicate {
+            if let Some(ref pred) = config.predicate {
+                source = source
+                    .with_predicate(Arc::clone(pred))
+                    .with_pushdown_filters(true)
+                    .with_reorder_filters(true);
+            }
+        }
+        FileScanConfigBuilder::new(config.store_url.clone(), Arc::new(source))
+            .with_file(partitioned_file)
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let config_builder = {
+        let _ = use_lc;
+        let _ = selectivity;
+        let mut source = parquet_source;
+        if push_predicate {
+            if let Some(ref pred) = config.predicate {
+                source = source
+                    .with_predicate(Arc::clone(pred))
+                    .with_pushdown_filters(true)
+                    .with_reorder_filters(true);
+            }
+        }
+        FileScanConfigBuilder::new(config.store_url.clone(), Arc::new(source))
+            .with_file(partitioned_file)
+    };
+
+    let mut config_builder = config_builder;
 
     if let Some(ref proj) = config.projection {
         // Empty projection (e.g. COUNT(*)) is honoured as "read no

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/indexed_table/stream.rs
@@ -681,12 +681,14 @@ impl IndexedStream {
         rg: &RowGroupInfo,
         selection: RowSelection,
         push_predicate: bool,
+        selectivity: f64,
     ) -> Result<(SendableRecordBatchStream, Arc<dyn ExecutionPlan>)> {
         parquet_bridge::create_row_selection_stream(
             &self.bridge_config(),
             rg.index,
             selection,
             push_predicate,
+            selectivity,
         )
     }
 
@@ -1059,6 +1061,11 @@ impl IndexedStream {
                     // Decide min_skip_run for this RG (see `pick_min_skip_run`).
                     let min_skip_run = self.pick_min_skip_run(candidates.len() as usize, rg.num_rows as usize);
 
+                    // Candidate selectivity for this RG (fraction of rows matched). Passed to
+                    // create_row_selection_stream so the liquid-cache engagement gate can decide
+                    // whether to route the scan through LiquidParquetSource (Linux only).
+                    let selectivity = candidates.len() as f64 / rg.num_rows as f64;
+
                     // Metrics: track which regime we landed in, using the
                     // same counters as before so `EXPLAIN ANALYZE` output
                     // stays comparable.
@@ -1138,7 +1145,7 @@ impl IndexedStream {
                         && !alignment_risk
                         && !self.evaluator.forbid_parquet_pushdown();
 
-                    match self.create_row_selection_stream(&rg, selection, push) {
+                    match self.create_row_selection_stream(&rg, selection, push, selectivity) {
                         Ok((stream, plan)) => {
                             if let Some(ref timer) = self.metrics.parquet_time {
                                 timer.add_duration(t_plan.elapsed());

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/lib.rs
@@ -59,6 +59,9 @@ pub mod task_monitors;
 pub mod scoped_index_optimizer;
 pub mod scoped_page_index_reader;
 
+#[cfg(target_os = "linux")]
+pub mod liquid_cache;
+
 // Path aliases — old module names still resolve unchanged.
 pub use cache::statistics_cache;
 pub use cache::eviction_policy;

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/liquid_cache.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/liquid_cache.rs
@@ -1,0 +1,240 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, AtomicU32, Ordering},
+        Arc, OnceLock,
+    },
+};
+
+use datafusion::{
+    common::DataFusionError,
+    physical_optimizer::PhysicalOptimizerRule,
+    prelude::SessionConfig,
+};
+
+use liquid_cache_datafusion_local::{
+    storage::cache::{squeeze_policies::TranscodeSqueezeEvict, CachePolicy, LiquidCache, NoHydration},
+    storage::cache_policies::{LiquidPolicy, LruPolicy},
+    LiquidCacheLocalBuilder,
+};
+use native_bridge_common::log_debug;
+
+const LOCAL_MODE_OPTIMIZER_NAME: &str = "LocalModeLiquidCacheOptimizer";
+const EVICTION_POLICY_LRU: &str = "lru";
+const CACHE_DIR_PREFIX: &str = "node_";
+
+static INSTANCE: OnceLock<Result<LiquidOnlyRuntime, String>> = OnceLock::new();
+
+// Dynamic tuning knobs — updated via cluster settings without restart.
+// Selectivity threshold stored as permille (800 = 0.800) to avoid floating-point atomics.
+static LC_SELECTIVITY_THRESHOLD_PERMILLE: AtomicU32 = AtomicU32::new(800);
+static LC_MAX_COLUMNS: AtomicU32 = AtomicU32::new(10);
+
+pub fn lc_selectivity_threshold() -> f64 {
+    LC_SELECTIVITY_THRESHOLD_PERMILLE.load(Ordering::Relaxed) as f64 / 1000.0
+}
+
+pub fn lc_max_columns() -> usize {
+    LC_MAX_COLUMNS.load(Ordering::Relaxed) as usize
+}
+
+pub fn set_lc_selectivity_threshold(value: f64) {
+    let permille = (value * 1000.0) as u32;
+    LC_SELECTIVITY_THRESHOLD_PERMILLE.store(permille, Ordering::Relaxed);
+}
+
+pub fn set_lc_max_columns(value: usize) {
+    LC_MAX_COLUMNS.store(value as u32, Ordering::Relaxed);
+}
+
+pub struct LiquidOnlyRuntime {
+    optimizer: Arc<dyn PhysicalOptimizerRule + Send + Sync>,
+    cache_ref: liquid_cache_datafusion::LiquidCacheParquetRef,
+    storage: Arc<LiquidCache>,
+    cache_dir: PathBuf,
+    enabled: AtomicBool,
+}
+
+impl LiquidOnlyRuntime {
+    pub fn init(
+        max_cache_bytes: u64,
+        max_disk_bytes: u64,
+        cache_dir: &str,
+        eviction_policy: &str,
+        tokio_handle: &tokio::runtime::Handle,
+    ) -> Result<&'static Self, DataFusionError> {
+        INSTANCE
+            .get_or_init(|| Self::build(max_cache_bytes, max_disk_bytes, cache_dir, eviction_policy, tokio_handle))
+            .as_ref()
+            .map_err(|e| DataFusionError::Execution(e.clone()))
+    }
+
+    fn build(
+        max_cache_bytes: u64,
+        max_disk_bytes: u64,
+        cache_dir: &str,
+        eviction_policy: &str,
+        tokio_handle: &tokio::runtime::Handle,
+    ) -> Result<Self, String> {
+        let cache_dir = PathBuf::from(cache_dir).join(format!("{}{}", CACHE_DIR_PREFIX, std::process::id()));
+        fs::create_dir_all(&cache_dir)
+            .map_err(|e| format!("Failed to create cache directory {:?}: {}", cache_dir, e))?;
+
+        let policy: Box<dyn CachePolicy> = match eviction_policy {
+            EVICTION_POLICY_LRU => Box::new(LruPolicy::new()),
+            _ => Box::new(LiquidPolicy::new()),
+        };
+
+        let builder = LiquidCacheLocalBuilder::new()
+            .with_max_memory_bytes(max_cache_bytes as usize)
+            .with_max_disk_bytes(max_disk_bytes as usize)
+            .with_cache_dir(cache_dir.clone())
+            .with_cache_policy(policy)
+            .with_squeeze_policy(Box::new(TranscodeSqueezeEvict))
+            .with_hydration_policy(Box::new(NoHydration::new()));
+
+        let (ctx, cache_ref) = tokio_handle
+            .block_on(builder.build(SessionConfig::new()))
+            .map_err(|e| format!("Failed to build liquid cache: {}", e))?;
+
+        let state = ctx.state();
+
+        let optimizer = state
+            .physical_optimizers()
+            .iter()
+            .find(|r| r.name() == LOCAL_MODE_OPTIMIZER_NAME)
+            .cloned()
+            .ok_or_else(|| format!("{} not found in session state", LOCAL_MODE_OPTIMIZER_NAME))?;
+
+        Ok(Self {
+            optimizer,
+            storage: cache_ref.storage().clone(),
+            cache_ref,
+            cache_dir,
+            enabled: AtomicBool::new(true),
+        })
+    }
+
+    pub fn optimizer(&self) -> Arc<dyn PhysicalOptimizerRule + Send + Sync> {
+        self.optimizer.clone()
+    }
+
+    pub fn cache_ref(&self) -> &liquid_cache_datafusion::LiquidCacheParquetRef {
+        &self.cache_ref
+    }
+
+    pub fn cache_ref_globally() -> Option<liquid_cache_datafusion::LiquidCacheParquetRef> {
+        Self::get().map(|rt| rt.cache_ref.clone())
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn set_max_memory_bytes(&self, bytes: usize) {
+        self.storage.budget().set_max_memory_bytes(bytes);
+    }
+
+    pub fn set_max_disk_bytes(&self, bytes: usize) {
+        self.storage.budget().set_max_disk_bytes(bytes);
+    }
+
+    pub fn reset_cache(&self) {
+        self.storage.reset();
+        self.recreate_cache_dir();
+        let stats = self.storage.stats();
+        log_debug!(
+            "[LiquidCache] cache cleared: entries={}, mem_usage={} bytes, disk_usage={} bytes",
+            stats.total_entries,
+            stats.memory_usage_bytes,
+            stats.disk_usage_bytes
+        );
+    }
+
+    pub fn log_stats(&self) {
+        let s = self.storage.stats();
+        log_debug!(
+            "[LiquidCache] entries={}, mem={}/{}, disk={}/{}, \
+             arrow={}({} B), liquid={}({} B), squeezed={}({} B), \
+             disk_liquid={}, disk_arrow={}",
+            s.total_entries,
+            s.memory_usage_bytes, s.max_memory_bytes,
+            s.disk_usage_bytes, s.max_disk_bytes,
+            s.memory_arrow_entries, s.memory_arrow_bytes,
+            s.memory_liquid_entries, s.memory_liquid_bytes,
+            s.memory_squeezed_liquid_entries, s.memory_squeezed_liquid_bytes,
+            s.disk_liquid_entries, s.disk_arrow_entries,
+        );
+        let mem_pct = if s.max_memory_bytes > 0 {
+            (s.memory_usage_bytes as f64 / s.max_memory_bytes as f64 * 100.0) as u64
+        } else { 0 };
+        log_debug!(
+            "[LiquidCache] hits={}, misses={}, predicate_evals={}, \
+             squeeze_ok={}, squeeze_io={}, read_io={}, write_io={}, \
+             disk_evict={}, squeeze_saved={}, mem_pressure={}%",
+            s.runtime.cache_hit, s.runtime.cache_miss,
+            s.runtime.eval_predicate,
+            s.runtime.get_squeezed_success, s.runtime.get_squeezed_needs_io,
+            s.runtime.read_io_count, s.runtime.write_io_count,
+            s.runtime.disk_evictions, s.runtime.squeeze_io_saved,
+            mem_pct,
+        );
+    }
+
+    fn recreate_cache_dir(&self) {
+        if self.cache_dir.exists() {
+            if let Err(e) = fs::remove_dir_all(&self.cache_dir) {
+                log_debug!("[LiquidCache] Failed to remove cache dir: {}", e);
+                return;
+            }
+        }
+        if let Err(e) = fs::create_dir_all(&self.cache_dir) {
+            log_debug!("[LiquidCache] Failed to recreate cache dir: {}", e);
+        }
+    }
+
+    fn get() -> Option<&'static Self> {
+        INSTANCE.get().and_then(|r| r.as_ref().ok())
+    }
+
+    pub fn is_enabled_globally() -> bool {
+        Self::get().map(|rt| rt.is_enabled()).unwrap_or(false)
+    }
+
+    pub fn set_enabled_globally(enabled: bool) {
+        if let Some(rt) = Self::get() {
+            rt.set_enabled(enabled);
+        }
+    }
+
+    pub fn set_max_memory_bytes_globally(bytes: usize) {
+        if let Some(rt) = Self::get() {
+            rt.set_max_memory_bytes(bytes);
+        }
+    }
+
+    pub fn set_max_disk_bytes_globally(bytes: usize) {
+        if let Some(rt) = Self::get() {
+            rt.set_max_disk_bytes(bytes);
+        }
+    }
+
+    pub fn log_stats_if_initialized() {
+        if let Some(rt) = Self::get() {
+            rt.log_stats();
+        }
+    }
+
+    pub fn reset_cache_if_initialized() {
+        if let Some(rt) = Self::get() {
+            rt.reset_cache();
+        }
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
+++ b/sandbox/plugins/analytics-backend-datafusion/rust/src/session_context.rs
@@ -210,6 +210,8 @@ pub async unsafe fn create_session_context(
     if !shard_view.sort_fields.is_empty() {
         config.options_mut().execution.split_file_groups_by_statistics = true;
     }
+    // LC session config is applied only when LC is actually engaged (inside
+    // parquet_bridge.rs), not globally.
 
     let mut state_builder = SessionStateBuilder::new()
         .with_config(config)
@@ -230,6 +232,16 @@ pub async unsafe fn create_session_context(
                 runtime.runtime_env.cache_manager.get_file_metadata_cache(),
             ),
         ));
+    }
+    // Only the physical optimizer (LocalModeLiquidCacheOptimizer) is applied.
+    // It wraps ParquetSource with LiquidParquetSource for decoded-batch caching.
+    // The LineageOptimizer (logical) is excluded — it adds O(nodes*exprs)
+    // planning overhead that causes 2x regression on string-heavy queries.
+    #[cfg(target_os = "linux")]
+    if crate::liquid_cache::LiquidOnlyRuntime::is_enabled_globally() {
+        if let Some(ref optimizer) = runtime.liquid_cache_optimizer {
+            state_builder = state_builder.with_physical_optimizer_rule(optimizer.clone());
+        }
     }
 
     let state = state_builder.build();
@@ -359,7 +371,7 @@ pub async unsafe fn create_session_context(
         shard_view.sort_fields.len()
     );
 
-    error!(
+    log_debug!(
         "create_session_context: successfully registered table '{}', table_name_len={}",
         table_name,
         table_name.len()

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -16,6 +16,7 @@ import org.opensearch.analytics.spi.QueryExecutionMetrics;
 import org.opensearch.arrow.allocator.ArrowNativeAllocator;
 import org.opensearch.arrow.spi.NativeAllocator;
 import org.opensearch.arrow.spi.PoolGroup;
+import org.opensearch.be.datafusion.action.LiquidCacheClearAction;
 import org.opensearch.be.datafusion.action.stats.DataFusionStatsActionType;
 import org.opensearch.be.datafusion.action.stats.RestDataFusionStatsAction;
 import org.opensearch.be.datafusion.action.stats.TransportDataFusionStatsAction;
@@ -33,6 +34,7 @@ import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.breaker.CircuitBreaker;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
@@ -560,6 +562,11 @@ public class DataFusionPlugin extends Plugin
             .spillDirectory(spillDir)
             .datanodeMultiplier(DatafusionSettings.CONCURRENCY_DATANODE_MULTIPLIER.get(settings))
             .clusterSettings(clusterService.getClusterSettings())
+            .liquidCacheEnabled(FeatureFlags.isEnabled(FeatureFlags.LIQUID_CACHE_EXPERIMENTAL_SETTING))
+            .liquidCacheSize(DatafusionSettings.LIQUID_CACHE_SIZE.get(settings))
+            .liquidCacheMaxDiskBytes(DatafusionSettings.LIQUID_CACHE_MAX_DISK_BYTES.get(settings))
+            .liquidCacheDir(DatafusionSettings.LIQUID_CACHE_DIR.get(settings))
+            .liquidCacheEvictionPolicy(DatafusionSettings.LIQUID_CACHE_EVICTION_POLICY.get(settings))
             .build();
         dataFusionService.start();
         logger.debug("DataFusion plugin initialized — memory pool {}B, spill limit {}B", memoryPoolLimit, spillMemoryLimit);
@@ -650,6 +657,27 @@ public class DataFusionPlugin extends Plugin
             DATAFUSION_MEMORY_GUARD_EXECUTION_SPILL_THRESHOLD.get(settings),
             DATAFUSION_MEMORY_GUARD_EXECUTION_CRITICAL_THRESHOLD.get(settings)
         );
+
+        // Wire Liquid Cache dynamic settings only when the experimental flag is enabled.
+        if (FeatureFlags.isEnabled(FeatureFlags.LIQUID_CACHE_EXPERIMENTAL_SETTING)) {
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(DatafusionSettings.LIQUID_CACHE_ENABLED,
+                enabled -> NativeBridge.setLiquidCacheEnabled(enabled));
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(DatafusionSettings.LIQUID_CACHE_SIZE,
+                bytes -> NativeBridge.setLiquidCacheMemoryLimit(bytes));
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(DatafusionSettings.LIQUID_CACHE_MAX_DISK_BYTES,
+                bytes -> NativeBridge.setLiquidCacheDiskLimit(bytes));
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(DatafusionSettings.LIQUID_CACHE_SELECTIVITY_THRESHOLD,
+                threshold -> NativeBridge.setLiquidCacheSelectivityThreshold((long) (threshold * 1000)));
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(DatafusionSettings.LIQUID_CACHE_MAX_COLUMNS,
+                count -> NativeBridge.setLiquidCacheMaxColumns((long) count));
+
+            NativeBridge.setLiquidCacheEnabled(DatafusionSettings.LIQUID_CACHE_ENABLED.get(settings));
+            NativeBridge.setLiquidCacheMemoryLimit(DatafusionSettings.LIQUID_CACHE_SIZE.get(settings));
+            NativeBridge.setLiquidCacheDiskLimit(DatafusionSettings.LIQUID_CACHE_MAX_DISK_BYTES.get(settings));
+            NativeBridge.setLiquidCacheSelectivityThreshold(
+                (long) (DatafusionSettings.LIQUID_CACHE_SELECTIVITY_THRESHOLD.get(settings) * 1000));
+            NativeBridge.setLiquidCacheMaxColumns((long) DatafusionSettings.LIQUID_CACHE_MAX_COLUMNS.get(settings));
+        }
 
         this.datafusionSettings = new DatafusionSettings(clusterService);
 
@@ -992,6 +1020,13 @@ public class DataFusionPlugin extends Plugin
     ) {
         if (dataFusionService == null) {
             return Collections.emptyList();
+        }
+        if (FeatureFlags.isEnabled(FeatureFlags.LIQUID_CACHE_EXPERIMENTAL_SETTING)) {
+            return List.of(
+                new RestDataFusionStatsAction(),
+                new org.opensearch.be.datafusion.action.stats.RestClearCacheAction(),
+                new LiquidCacheClearAction(dataFusionService)
+            );
         }
         return List.of(new RestDataFusionStatsAction(), new org.opensearch.be.datafusion.action.stats.RestClearCacheAction());
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionService.java
@@ -49,6 +49,11 @@ public class DataFusionService extends AbstractLifecycleComponent {
     private final double datanodeMultiplier;
     private final double coordinatorMultiplier;
     private final ClusterSettings clusterSettings;
+    private final boolean liquidCacheEnabled;
+    private final long liquidCacheSize;
+    private final long liquidCacheMaxDiskBytes;
+    private final String liquidCacheDir;
+    private final String liquidCacheEvictionPolicy;
 
     /** Handle to the native DataFusion global runtime (memory pool + cache). */
     private volatile NativeRuntimeHandle runtimeHandle;
@@ -64,6 +69,11 @@ public class DataFusionService extends AbstractLifecycleComponent {
         this.datanodeMultiplier = builder.datanodeMultiplier;
         this.coordinatorMultiplier = builder.coordinatorMultiplier;
         this.clusterSettings = builder.clusterSettings;
+        this.liquidCacheEnabled = builder.liquidCacheEnabled;
+        this.liquidCacheSize = builder.liquidCacheSize;
+        this.liquidCacheMaxDiskBytes = builder.liquidCacheMaxDiskBytes;
+        this.liquidCacheDir = builder.liquidCacheDir;
+        this.liquidCacheEvictionPolicy = builder.liquidCacheEvictionPolicy;
     }
 
     /** Creates a new builder. */
@@ -98,7 +108,8 @@ public class DataFusionService extends AbstractLifecycleComponent {
         }
 
         try {
-            long ptr = NativeBridge.createGlobalRuntime(memoryPoolLimit, cacheManagerPtr, spillDirectory, spillMemoryLimit);
+            long ptr = NativeBridge.createGlobalRuntime(memoryPoolLimit, cacheManagerPtr, spillDirectory, spillMemoryLimit,
+                liquidCacheEnabled, liquidCacheSize, liquidCacheMaxDiskBytes, liquidCacheDir, liquidCacheEvictionPolicy);
             if (cacheHandle != null) {
                 cacheHandle.markConsumed();
             }
@@ -296,6 +307,13 @@ public class DataFusionService extends AbstractLifecycleComponent {
         }
     }
 
+    /**
+     * Clears the Liquid Cache and DataFusion internal caches.
+     */
+    public void clearLiquidCache() {
+        NativeBridge.clearLiquidCache(getNativeRuntime().get());
+    }
+
     private void releaseRuntime() {
         NativeRuntimeHandle handle = runtimeHandle;
         if (handle != null) {
@@ -316,6 +334,11 @@ public class DataFusionService extends AbstractLifecycleComponent {
         private double datanodeMultiplier = 1.0;
         private double coordinatorMultiplier = 1.0;
         private ClusterSettings clusterSettings;
+        private boolean liquidCacheEnabled = false;
+        private long liquidCacheSize = 1L * 1024 * 1024 * 1024; // 1GB default
+        private long liquidCacheMaxDiskBytes = Long.MAX_VALUE;
+        private String liquidCacheDir = "/tmp/opensearch/liquid_cache";
+        private String liquidCacheEvictionPolicy = "lru";
 
         private Builder() {}
 
@@ -373,6 +396,51 @@ public class DataFusionService extends AbstractLifecycleComponent {
          */
         public Builder clusterSettings(ClusterSettings clusterSettings) {
             this.clusterSettings = clusterSettings;
+            return this;
+        }
+
+        /**
+         * Enables or disables Liquid Cache for byte-level Parquet caching.
+         * @param enabled whether to enable liquid cache
+         */
+        public Builder liquidCacheEnabled(boolean enabled) {
+            this.liquidCacheEnabled = enabled;
+            return this;
+        }
+
+        /**
+         * Sets the Liquid Cache size in bytes.
+         * @param bytes cache size limit
+         */
+        public Builder liquidCacheSize(long bytes) {
+            this.liquidCacheSize = bytes;
+            return this;
+        }
+
+        /**
+         * Sets the Liquid Cache max disk size in bytes.
+         * @param bytes max disk limit
+         */
+        public Builder liquidCacheMaxDiskBytes(long bytes) {
+            this.liquidCacheMaxDiskBytes = bytes;
+            return this;
+        }
+
+        /**
+         * Sets the Liquid Cache directory for disk-spilled entries.
+         * @param dir the cache directory path
+         */
+        public Builder liquidCacheDir(String dir) {
+            this.liquidCacheDir = dir;
+            return this;
+        }
+
+        /**
+         * Sets the Liquid Cache eviction policy (liquid, lru).
+         * @param policy the eviction policy
+         */
+        public Builder liquidCacheEvictionPolicy(String policy) {
+            this.liquidCacheEvictionPolicy = policy;
             return this;
         }
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DatafusionSettings.java
@@ -188,6 +188,92 @@ public final class DatafusionSettings {
 
     // ── All settings registered by the plugin ──
 
+    /**
+     * Dynamically enables or disables Liquid Cache for new queries.
+     * When false, optimizers are not injected and queries bypass the cache.
+     * The cache remains initialized (for fast re-enable) but idle.
+     */
+    public static final Setting<Boolean> LIQUID_CACHE_ENABLED = Setting.boolSetting(
+        "datafusion.liquid_cache.enabled",
+        true,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Controls the Liquid Cache max memory size in bytes for byte-level Parquet caching.
+     * Only used when liquid cache is enabled via the experimental feature flag.
+     */
+    public static final Setting<Long> LIQUID_CACHE_SIZE = Setting.longSetting(
+        "datafusion.liquid_cache.size_bytes",
+        1L * 1024 * 1024 * 1024, // 1GB default
+        0L,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Controls the Liquid Cache max disk size in bytes.
+     * Entries evicted from memory are written to disk up to this limit.
+     * Default is unlimited (Long.MAX_VALUE).
+     */
+    public static final Setting<Long> LIQUID_CACHE_MAX_DISK_BYTES = Setting.longSetting(
+        "datafusion.liquid_cache.max_disk_bytes",
+        Long.MAX_VALUE,
+        0L,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Directory for Liquid Cache disk-spilled entries.
+     */
+    public static final Setting<String> LIQUID_CACHE_DIR = Setting.simpleString(
+        "datafusion.liquid_cache.cache_dir",
+        "/tmp/opensearch/liquid_cache",
+        Setting.Property.NodeScope,
+        Setting.Property.Final
+    );
+
+    /**
+     * Liquid Cache eviction policy.
+     * <ul>
+     *   <li>{@code liquid} (default) — Independent FIFO queues per batch type (LiquidPolicy)</li>
+     *   <li>{@code lru} — Standard LRU eviction across all entry types</li>
+     * </ul>
+     */
+    public static final Setting<String> LIQUID_CACHE_EVICTION_POLICY = Setting.simpleString(
+        "datafusion.liquid_cache.eviction_policy",
+        "lru",
+        Setting.Property.NodeScope,
+        Setting.Property.Final
+    );
+
+    /**
+     * Selectivity threshold for LC STREAM vs DELEGATE (0.0 to 1.0).
+     * Files with selectivity below this threshold are delegated to plain parquet.
+     */
+    public static final Setting<Float> LIQUID_CACHE_SELECTIVITY_THRESHOLD = Setting.floatSetting(
+        "datafusion.liquid_cache.selectivity_threshold",
+        0.8f,
+        0.0f,
+        1.0f,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Maximum number of output columns for LC engagement.
+     * Queries projecting more columns than this are skipped by the optimizer.
+     */
+    public static final Setting<Integer> LIQUID_CACHE_MAX_COLUMNS = Setting.intSetting(
+        "datafusion.liquid_cache.max_columns",
+        10,
+        1,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     public static final List<Setting<?>> ALL_SETTINGS = List.of(
 
         // Runtime settings — memory pool, spill, reduce input mode, and budget tuning
@@ -229,7 +315,16 @@ public final class DatafusionSettings {
         INDEXED_PUSHDOWN_FILTERS,
         INDEXED_MIN_SKIP_RUN_DEFAULT,
         INDEXED_MIN_SKIP_RUN_SELECTIVITY_THRESHOLD,
-        INDEXED_FORCE_STRATEGY
+        INDEXED_FORCE_STRATEGY,
+
+        // Liquid cache settings (feature-flagged; see FeatureFlags.LIQUID_CACHE_EXPERIMENTAL_SETTING)
+        LIQUID_CACHE_ENABLED,
+        LIQUID_CACHE_SIZE,
+        LIQUID_CACHE_MAX_DISK_BYTES,
+        LIQUID_CACHE_DIR,
+        LIQUID_CACHE_EVICTION_POLICY,
+        LIQUID_CACHE_SELECTIVITY_THRESHOLD,
+        LIQUID_CACHE_MAX_COLUMNS
     );
 
     // ── Snapshot management ──

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/LiquidCacheClearAction.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/action/LiquidCacheClearAction.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.be.datafusion.action;
+
+import org.opensearch.be.datafusion.DataFusionService;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+/**
+ * REST handler for {@code POST _plugins/analytics_backend_datafusion/liquid_cache/clear}.
+ * <p>
+ * Clears all Liquid Cache entries (in-memory + disk) and DataFusion internal caches.
+ */
+public class LiquidCacheClearAction extends BaseRestHandler {
+
+    private static final Logger logger = LogManager.getLogger(LiquidCacheClearAction.class);
+    private final DataFusionService dataFusionService;
+
+    public LiquidCacheClearAction(DataFusionService dataFusionService) {
+        this.dataFusionService = dataFusionService;
+    }
+
+    @Override
+    public String getName() {
+        return "liquid_cache_clear_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(RestRequest.Method.POST, "_plugins/analytics_backend_datafusion/liquid_cache/clear"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        return channel -> {
+            try {
+                logger.info("Clearing Liquid Cache via REST endpoint");
+                dataFusionService.clearLiquidCache();
+                logger.info("Liquid Cache cleared successfully");
+                XContentBuilder builder = channel.newBuilder();
+                builder.startObject();
+                builder.field("acknowledged", true);
+                builder.endObject();
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+            } catch (Exception e) {
+                channel.sendResponse(new BytesRestResponse(channel, e));
+            }
+        };
+    }
+}

--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/nativelib/NativeBridge.java
@@ -143,6 +143,12 @@ public final class NativeBridge {
     private static final MethodHandle SET_SCOPED_PAGE_INDEX_ENABLED;
     private static final MethodHandle CANCEL_QUERY;
     private static final MethodHandle SET_CANCEL_STATS_THRESHOLD_MS;
+    private static final MethodHandle CLEAR_LIQUID_CACHE;
+    private static final MethodHandle SET_LIQUID_CACHE_ENABLED;
+    private static final MethodHandle SET_LIQUID_CACHE_MEMORY_LIMIT;
+    private static final MethodHandle SET_LIQUID_CACHE_DISK_LIMIT;
+    private static final MethodHandle SET_LIQUID_CACHE_SELECTIVITY_THRESHOLD;
+    private static final MethodHandle SET_LIQUID_CACHE_MAX_COLUMNS;
     private static final MethodHandle STATS;
     private static final MethodHandle QUERY_REGISTRY_TOP_N_BY_CURRENT;
     private static final MethodHandle DF_NATIVE_NODE_STATS;
@@ -174,12 +180,49 @@ public final class NativeBridge {
                 ValueLayout.JAVA_LONG,
                 ValueLayout.ADDRESS,
                 ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,
                 ValueLayout.JAVA_LONG
             )
         );
 
         CLOSE_GLOBAL_RUNTIME = linker.downcallHandle(
             lib.find("df_close_global_runtime").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
+        );
+
+        CLEAR_LIQUID_CACHE = linker.downcallHandle(
+            lib.find("df_clear_liquid_cache").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
+        );
+
+        SET_LIQUID_CACHE_ENABLED = linker.downcallHandle(
+            lib.find("df_set_liquid_cache_enabled").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
+        );
+
+        SET_LIQUID_CACHE_MEMORY_LIMIT = linker.downcallHandle(
+            lib.find("df_set_liquid_cache_memory_limit").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
+        );
+
+        SET_LIQUID_CACHE_DISK_LIMIT = linker.downcallHandle(
+            lib.find("df_set_liquid_cache_disk_limit").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
+        );
+
+        SET_LIQUID_CACHE_SELECTIVITY_THRESHOLD = linker.downcallHandle(
+            lib.find("df_set_liquid_cache_selectivity_threshold").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
+        );
+
+        SET_LIQUID_CACHE_MAX_COLUMNS = linker.downcallHandle(
+            lib.find("df_set_liquid_cache_max_columns").orElseThrow(),
             FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
         );
 
@@ -768,16 +811,52 @@ public final class NativeBridge {
      * This pointer is <b>not</b> a MemorySegment — it's a Rust heap address that lives
      * until {@link #closeGlobalRuntime} is called.
      */
-    public static long createGlobalRuntime(long memoryLimit, long cacheManagerPtr, String spillDir, long spillLimit) {
+    public static long createGlobalRuntime(long memoryLimit, long cacheManagerPtr, String spillDir, long spillLimit,
+                                           boolean liquidCacheEnabled, long liquidCacheSize, long liquidCacheMaxDiskBytes,
+                                           String liquidCacheDir, String liquidCacheEvictionPolicy) {
         try (var call = new NativeCall()) {
             var dir = call.str(spillDir);
-            return call.invoke(CREATE_GLOBAL_RUNTIME, memoryLimit, cacheManagerPtr, dir.segment(), dir.len(), spillLimit);
+            var cacheDir = call.str(liquidCacheDir);
+            var eviction = call.str(liquidCacheEvictionPolicy);
+            return call.invoke(CREATE_GLOBAL_RUNTIME, memoryLimit, cacheManagerPtr, dir.segment(), dir.len(), spillLimit,
+                liquidCacheEnabled ? 1L : 0L, liquidCacheSize, liquidCacheMaxDiskBytes,
+                cacheDir.segment(), cacheDir.len(), eviction.segment(), eviction.len());
         }
     }
 
     /** Frees the native runtime. Safe to call once. */
     public static void closeGlobalRuntime(long ptr) {
         NativeCall.invokeVoid(CLOSE_GLOBAL_RUNTIME, ptr);
+    }
+
+    /** Clears all Liquid Cache entries and DataFusion internal caches. */
+    public static void clearLiquidCache(long runtimePtr) {
+        NativeCall.invokeVoid(CLEAR_LIQUID_CACHE, runtimePtr);
+    }
+
+    /** Dynamically enable or disable Liquid Cache for new queries. */
+    public static void setLiquidCacheEnabled(boolean enabled) {
+        NativeCall.invokeVoid(SET_LIQUID_CACHE_ENABLED, enabled ? 1L : 0L);
+    }
+
+    /** Dynamically update the Liquid Cache memory limit in bytes. */
+    public static void setLiquidCacheMemoryLimit(long bytes) {
+        NativeCall.invokeVoid(SET_LIQUID_CACHE_MEMORY_LIMIT, bytes);
+    }
+
+    /** Dynamically update the Liquid Cache disk limit in bytes. */
+    public static void setLiquidCacheDiskLimit(long bytes) {
+        NativeCall.invokeVoid(SET_LIQUID_CACHE_DISK_LIMIT, bytes);
+    }
+
+    /** Dynamically update the LC selectivity threshold (permille: 800 = 0.8). */
+    public static void setLiquidCacheSelectivityThreshold(long permille) {
+        NativeCall.invokeVoid(SET_LIQUID_CACHE_SELECTIVITY_THRESHOLD, permille);
+    }
+
+    /** Dynamically update the max columns for LC engagement. */
+    public static void setLiquidCacheMaxColumns(long count) {
+        NativeCall.invokeVoid(SET_LIQUID_CACHE_MAX_COLUMNS, count);
     }
 
     // ---- Memory pool observability and dynamic limit ----

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionNativeBridgeTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionNativeBridgeTests.java
@@ -51,7 +51,12 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
             64 * 1024 * 1024, // 64MB
             0L,
             spillDir.toString(),
-            32 * 1024 * 1024 // 32MB spill
+            32 * 1024 * 1024, // 32MB spill
+            false,
+            0L,
+            Long.MAX_VALUE,
+            "/tmp/opensearch/liquid_cache",
+            "liquid"
         );
         assertTrue("Runtime pointer should be non-zero", runtimePtr != 0);
 
@@ -62,7 +67,7 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
     public void testReaderLifecycle() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
 
         // Copy test parquet to a temp dir
         Path dataDir = createTempDir("datafusion-data");
@@ -88,7 +93,7 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
     public void testSessionContextCreationAndTableRegistration() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
 
         Path dataDir = createTempDir("datafusion-data");
@@ -166,7 +171,7 @@ public class DataFusionNativeBridgeTests extends OpenSearchTestCase {
     public void testReaderWithRealNativeStoreHandle() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
 
         // Copy test parquet to a temp dir
         Path dataDir = createTempDir("datafusion-data");

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionPluginSettingsTests.java
@@ -67,6 +67,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testPluginRegistersMemoryPoolLimitSetting() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
+            assertEquals(36, settings.size());
             assertTrue(
                 "Plugin must register DATAFUSION_MEMORY_POOL_LIMIT via getSettings()",
                 settings.contains(DataFusionPlugin.DATAFUSION_MEMORY_POOL_LIMIT)
@@ -97,6 +98,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsAllIndexedSettings() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
+            assertEquals(36, settings.size());
             Set<String> settingKeys = settings.stream().map(Setting::getKey).collect(Collectors.toSet());
 
             assertTrue(settingKeys.contains("datafusion.batch_size"));
@@ -111,7 +113,7 @@ public class DataFusionPluginSettingsTests extends OpenSearchTestCase {
     public void testGetSettingsReturnsTotalExpectedCount() {
         try (DataFusionPlugin plugin = new DataFusionPlugin()) {
             List<Setting<?>> settings = plugin.getSettings();
-            assertEquals(31, settings.size());
+            assertEquals(38, settings.size());
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionQueryExecutionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionQueryExecutionTests.java
@@ -53,7 +53,7 @@ public class DataFusionQueryExecutionTests extends OpenSearchTestCase {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
         runtimeHandle = new NativeRuntimeHandle(
-            NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir.toString(), 64 * 1024 * 1024)
+            NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir.toString(), 64 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru")
         );
 
         // Create a real TieredObjectStore (local-only) and wrap in NativeStoreHandle

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DataFusionServiceTests.java
@@ -82,7 +82,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
     public void testNativeRuntimeHandleCloseIsIdempotent() {
         ensureTokioInit();
         Path spillDir = createTempDir("spill");
-        long ptr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long ptr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle handle = new NativeRuntimeHandle(ptr);
 
         assertTrue(handle.isOpen());
@@ -96,7 +96,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
     public void testNativeRuntimeHandleGetAfterCloseThrows() {
         ensureTokioInit();
         Path spillDir = createTempDir("spill");
-        long ptr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long ptr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle handle = new NativeRuntimeHandle(ptr);
         handle.close();
         expectThrows(IllegalStateException.class, handle::get);
@@ -202,7 +202,7 @@ public class DataFusionServiceTests extends OpenSearchTestCase {
         NativeBridge.createCache(cachePtr, "STATISTICS", 100 * 1024 * 1024, "LRU");
 
         Path spillDir = createTempDir("spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, cachePtr, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, cachePtr, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         assertTrue(runtimePtr != 0);
 
         NativeBridge.closeGlobalRuntime(runtimePtr);

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionMemtableReduceSinkTests.java
@@ -59,7 +59,7 @@ public class DatafusionMemtableReduceSinkTests extends OpenSearchTestCase {
     public void testFeedDrainsSumToDownstream() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         assertTrue("runtime ptr non-zero", runtimePtr != 0);
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
 

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionReduceSinkTests.java
@@ -107,7 +107,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
     public void testFeedDrainsSumToDownstream() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         assertTrue("runtime ptr non-zero", runtimePtr != 0);
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
 
@@ -214,7 +214,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
     public void testDrainTaskKeepsUpWithProducer() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
 
         try (RootAllocator alloc = new RootAllocator(Long.MAX_VALUE)) {
@@ -268,7 +268,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
     public void testReduceProducesOutputIncrementallyForPipelinedPlan() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
 
         try (RootAllocator alloc = new RootAllocator(Long.MAX_VALUE)) {
@@ -421,7 +421,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
     public void testCancelBeforeFirstBatchUnwindsDrain() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
 
         try (RootAllocator alloc = new RootAllocator(Long.MAX_VALUE)) {
@@ -473,7 +473,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
     public void testCancelAfterFirstBatchUnwindsDrain() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
 
         try (RootAllocator alloc = new RootAllocator(Long.MAX_VALUE)) {
@@ -519,7 +519,7 @@ public class DatafusionReduceSinkTests extends OpenSearchTestCase {
     public void testDoubleCloseIsIdempotent() throws Exception {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
 
         try (RootAllocator alloc = new RootAllocator(Long.MAX_VALUE)) {

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionResultStreamTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionResultStreamTests.java
@@ -47,7 +47,7 @@ public class DatafusionResultStreamTests extends OpenSearchTestCase {
         super.setUp();
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("spill");
-        long ptr = NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir.toString(), 64 * 1024 * 1024);
+        long ptr = NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir.toString(), 64 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         runtimeHandle = new NativeRuntimeHandle(ptr);
         testRootAllocator = new RootAllocator(Long.MAX_VALUE);
 
@@ -237,7 +237,7 @@ public class DatafusionResultStreamTests extends OpenSearchTestCase {
         // Create a valid stream, close the runtime handle to force streamNext failure,
         // then verify the stream still closes cleanly
         Path spillDir2 = createTempDir("spill2");
-        long ptr2 = NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir2.toString(), 64 * 1024 * 1024);
+        long ptr2 = NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir2.toString(), 64 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle tempRuntime = new NativeRuntimeHandle(ptr2);
 
         byte[] substrait = NativeBridge.sqlToSubstrait(

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSearchExecEngineTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSearchExecEngineTests.java
@@ -44,7 +44,7 @@ public class DatafusionSearchExecEngineTests extends OpenSearchTestCase {
         super.setUp();
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long ptr = NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir.toString(), 64 * 1024 * 1024);
+        long ptr = NativeBridge.createGlobalRuntime(128 * 1024 * 1024, 0L, spillDir.toString(), 64 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         runtimeHandle = new NativeRuntimeHandle(ptr);
 
         // Create a real TieredObjectStore (local-only) and wrap in NativeStoreHandle

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/DatafusionSettingsTests.java
@@ -55,7 +55,7 @@ public class DatafusionSettingsTests extends OpenSearchTestCase {
     }
 
     public void testAllSettingsContainsAllExpectedSettings() {
-        assertEquals(31, DatafusionSettings.ALL_SETTINGS.size());
+        assertEquals(38, DatafusionSettings.ALL_SETTINGS.size());
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_REDUCE_TARGET_PARTITIONS));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_MEMORY_GUARD_SPILL_EXEMPT_CAP));
         assertTrue(DatafusionSettings.ALL_SETTINGS.contains(DataFusionPlugin.DATAFUSION_SPILL_DIRECTORY));

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeBridgeLocalSessionTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeBridgeLocalSessionTests.java
@@ -53,7 +53,7 @@ public class NativeBridgeLocalSessionTests extends OpenSearchTestCase {
     private NativeRuntimeHandle createRuntime() {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         assertTrue("runtime ptr non-zero", runtimePtr != 0);
         return new NativeRuntimeHandle(runtimePtr);
     }

--- a/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeBridgePreparedPlanTests.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/test/java/org/opensearch/be/datafusion/NativeBridgePreparedPlanTests.java
@@ -42,7 +42,7 @@ public class NativeBridgePreparedPlanTests extends OpenSearchTestCase {
     public void testPrepareFinalPlanWithInvalidBytesThrowsDecodeError() {
         NativeBridge.initTokioRuntimeManager(2);
         Path spillDir = createTempDir("datafusion-spill");
-        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024);
+        long runtimePtr = NativeBridge.createGlobalRuntime(64 * 1024 * 1024, 0L, spillDir.toString(), 32 * 1024 * 1024, false, 0L, Long.MAX_VALUE, "/tmp/opensearch/liquid_cache", "lru");
         NativeRuntimeHandle runtimeHandle = new NativeRuntimeHandle(runtimePtr);
         DatafusionLocalSession session = new DatafusionLocalSession(runtimeHandle.get());
         try {

--- a/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReader.java
+++ b/sandbox/plugins/analytics-backend-lucene/src/main/java/org/opensearch/be/lucene/LuceneReader.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.engine.exec.SearchableDirectoryReaderProvider;
 
 import java.util.Map;
 import java.util.Objects;
@@ -23,9 +24,17 @@ import java.util.Objects;
  * searcher rather than building their own: distinct {@code IndexSearcher}s over the same reader,
  * both wired to the shared query cache, trip Lucene's "top-reader used to create Weight is not the
  * same as the current reader's top-reader" assertion — fatal across the FFM boundary.
+ *
+ * <p>The generation→segment map is built at refresh time by {@link LuceneReaderManager#afterRefresh}
+ * and consumed by {@link LuceneFilterDelegationHandle} — no attribute reads or file-set matching at
+ * query time.
+ *
+ * <p>Implements {@link SearchableDirectoryReaderProvider} so that the server module's
+ * {@code DataFormatAwareEngine} can obtain the {@link DirectoryReader} for the standard search path
+ * without depending on this plugin at compile time.
  */
 @ExperimentalApi
-public final class LuceneReader {
+public final class LuceneReader implements SearchableDirectoryReaderProvider {
 
     private final DirectoryReader directoryReader;
     private final Map<Long, String> generationToSegmentName;

--- a/sandbox/plugins/composite-engine/build.gradle
+++ b/sandbox/plugins/composite-engine/build.gradle
@@ -51,6 +51,8 @@ dependencies {
   api project(':libs:opensearch-concurrent-queue')
   implementation project(':sandbox:libs:plugin-stats-spi')
   compileOnly project(':server')
+  // Parquet DocValues codec (ParquetDocValuesFormat) for per-field routing at the segment level.
+  compileOnly project(':sandbox:plugins:parquet-data-format')
   testImplementation project(':test:framework')
   testImplementation project(':sandbox:plugins:parquet-data-format')
   testImplementation project(':sandbox:plugins:analytics-backend-lucene')

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/codec/CompositeParquetDocValuesFormat.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/codec/CompositeParquetDocValuesFormat.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite.codec;
+
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
+import org.opensearch.common.annotation.ExperimentalApi;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.parquet.codec.ParquetDocValuesFormat;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Segment-level {@link PerFieldDocValuesFormat} that routes a field's doc values to the
+ * Parquet-backed {@link ParquetDocValuesFormat} when the field is Parquet-resident, and to
+ * Lucene's native {@link Lucene90DocValuesFormat} otherwise. This lets the two formats coexist
+ * within a single segment on a per-field basis (Req 13.3).
+ *
+ * <h2>Routing</h2>
+ * A field is routed to Parquet when its {@code docValueFormats} list (supplied per-field by the
+ * {@code docValueFormatsResolver}) contains {@code "parquet"}. When the list is
+ * {@code ["parquet", "lucene"]} (both present), Parquet is chosen by default; this matches the
+ * design's "default to Parquet unless overridden" rule. When the resolver returns {@code null}
+ * or an empty/absent list, the field falls through to the Lucene native format.
+ *
+ * <h2>How the per-field binding is persisted</h2>
+ * Lucene's {@link PerFieldDocValuesFormat#fieldsConsumer} stamps the chosen format's SPI name
+ * into the segment's per-field attribute ({@link PerFieldDocValuesFormat#PER_FIELD_FORMAT_KEY},
+ * i.e. {@code "PerFieldDocValuesFormat.format"}) at write time, and
+ * {@link PerFieldDocValuesFormat#fieldsProducer} reads it back and resolves the format by SPI
+ * name at read time. We therefore only override {@link #getDocValuesFormatForField(String)} —
+ * the attribute stamping and read-time routing come for free.
+ */
+@ExperimentalApi
+public final class CompositeParquetDocValuesFormat extends PerFieldDocValuesFormat {
+
+    /**
+     * Logical identifier for this composite routing format, mirroring the {@code Composite912}
+     * naming. Note: the SPI name reported to Lucene is fixed by {@link PerFieldDocValuesFormat}
+     * to {@link PerFieldDocValuesFormat#PER_FIELD_NAME}; this constant is for diagnostics and
+     * callers that want to refer to the composite format by a stable label.
+     */
+    public static final String FORMAT_NAME = "CompositeParquetDocValues";
+
+    /** Doc-value format name that marks a field as Parquet-resident. */
+    public static final String PARQUET_FORMAT = "parquet";
+
+    private final DocValuesFormat parquetFormat;
+    private final DocValuesFormat luceneFormat;
+
+    /**
+     * Resolves a field name to its {@code docValueFormats} list (e.g. {@code ["parquet"]},
+     * {@code ["parquet", "lucene"]}, {@code ["lucene"]}). May return {@code null} for unknown
+     * fields, in which case the field routes to the Lucene native format.
+     */
+    private final Function<String, List<String>> docValueFormatsResolver;
+
+    /**
+     * @param mapperService            passed to the Parquet format so its producer can validate
+     *                                 OpenSearch mapping types
+     * @param docValueFormatsResolver  field name → its {@code docValueFormats} list
+     */
+    public CompositeParquetDocValuesFormat(MapperService mapperService, Function<String, List<String>> docValueFormatsResolver) {
+        super();
+        this.parquetFormat = new ParquetDocValuesFormat(mapperService);
+        this.luceneFormat = new Lucene90DocValuesFormat();
+        this.docValueFormatsResolver = Objects.requireNonNull(docValueFormatsResolver, "docValueFormatsResolver");
+    }
+
+    @Override
+    public DocValuesFormat getDocValuesFormatForField(String field) {
+        List<String> formats = docValueFormatsResolver.apply(field);
+        if (isParquetResident(formats)) {
+            return parquetFormat;
+        }
+        return luceneFormat;
+    }
+
+    /**
+     * True when {@code formats} marks the field as Parquet-resident. A list containing
+     * {@code "parquet"} routes to Parquet; this includes the {@code ["parquet", "lucene"]} case,
+     * where Parquet is the default for queries unless explicitly overridden elsewhere.
+     */
+    static boolean isParquetResident(List<String> formats) {
+        return formats != null && formats.contains(PARQUET_FORMAT);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT, "CompositeParquetDocValuesFormat(parquet=%s, lucene=%s)", parquetFormat, luceneFormat);
+    }
+}

--- a/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/codec/package-info.java
+++ b/sandbox/plugins/composite-engine/src/main/java/org/opensearch/composite/codec/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Segment-level codec wiring for the composite engine. Routes per-field doc values between the
+ * Parquet-backed codec and Lucene's native format via {@code PerFieldDocValuesFormat}.
+ */
+package org.opensearch.composite.codec;

--- a/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/codec/CompositeParquetDocValuesFormatTests.java
+++ b/sandbox/plugins/composite-engine/src/test/java/org/opensearch/composite/codec/CompositeParquetDocValuesFormatTests.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.composite.codec;
+
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.opensearch.parquet.codec.ParquetDocValuesFormat;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link CompositeParquetDocValuesFormat} per-field routing (Req 13.1, 13.2,
+ * 13.3). Pure-Java: verifies the routing decision and dispatch without writing a segment.
+ */
+public class CompositeParquetDocValuesFormatTests extends OpenSearchTestCase {
+
+    public void testIsParquetResident() {
+        assertTrue(CompositeParquetDocValuesFormat.isParquetResident(List.of("parquet")));
+        assertTrue(
+            "both formats present defaults to parquet",
+            CompositeParquetDocValuesFormat.isParquetResident(List.of("parquet", "lucene"))
+        );
+        assertFalse(CompositeParquetDocValuesFormat.isParquetResident(List.of("lucene")));
+        assertFalse(CompositeParquetDocValuesFormat.isParquetResident(List.of()));
+        assertFalse(CompositeParquetDocValuesFormat.isParquetResident(null));
+    }
+
+    public void testPerFieldRoutingDispatch() {
+        Map<String, List<String>> routing = Map.of(
+            "price",
+            List.of("parquet"),
+            "tags",
+            List.of("parquet", "lucene"),
+            "title",
+            List.of("lucene")
+        );
+        CompositeParquetDocValuesFormat format = new CompositeParquetDocValuesFormat(null, f -> routing.get(f));
+
+        // Parquet-routed fields dispatch to the Parquet format.
+        DocValuesFormat priceFormat = format.getDocValuesFormatForField("price");
+        assertEquals(ParquetDocValuesFormat.FORMAT_NAME, priceFormat.getName());
+
+        DocValuesFormat tagsFormat = format.getDocValuesFormatForField("tags");
+        assertEquals("both-formats field defaults to Parquet", ParquetDocValuesFormat.FORMAT_NAME, tagsFormat.getName());
+
+        // Lucene-routed and unknown fields dispatch to the native Lucene format (not Parquet).
+        DocValuesFormat titleFormat = format.getDocValuesFormatForField("title");
+        assertNotEquals(ParquetDocValuesFormat.FORMAT_NAME, titleFormat.getName());
+
+        DocValuesFormat unknownFormat = format.getDocValuesFormatForField("does_not_exist");
+        assertNotEquals(ParquetDocValuesFormat.FORMAT_NAME, unknownFormat.getName());
+    }
+}

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/DslQueryExecutorPlugin.java
@@ -12,6 +12,7 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -59,8 +60,13 @@ public class DslQueryExecutorPlugin extends Plugin implements ActionPlugin {
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        this.searchActionFilter = new SearchActionFilter((NodeClient) client);
+        this.searchActionFilter = new SearchActionFilter((NodeClient) client, clusterService);
         return Collections.emptyList();
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(SearchActionFilter.INTERCEPT_SEARCH_ENABLED);
     }
 
     @Override

--- a/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
+++ b/sandbox/plugins/dsl-query-executor/src/main/java/org/opensearch/dsl/action/SearchActionFilter.java
@@ -15,6 +15,8 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.tasks.Task;
@@ -26,18 +28,36 @@ import org.opensearch.transport.client.node.NodeClient;
  */
 public class SearchActionFilter implements ActionFilter {
 
+    /**
+     * Controls whether this filter intercepts {@code _search} and routes it through the Calcite/DSL
+     * pipeline. Default {@code true} preserves the plugin's original intercept behavior; set to
+     * {@code false} to let {@code _search} reach the standard aggregation path (and thus aggregation
+     * delegation on composite-engine indexes).
+     */
+    public static final Setting<Boolean> INTERCEPT_SEARCH_ENABLED = Setting.boolSetting(
+        "dsl.query_executor.intercept_search.enabled",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     /** Runs after the Security plugin's authorization filter (order 0). */
     static final int FILTER_ORDER = 1;
 
     private final NodeClient client;
+    private volatile boolean interceptEnabled;
 
     /**
-     * Creates a filter that dispatches intercepted searches via the given client.
+     * Creates a filter that dispatches intercepted searches via the given client. The interception
+     * gate is initialised from the cluster settings and kept in sync with dynamic updates.
      *
-     * @param client node client for dispatching to {@link DslExecuteAction}
+     * @param client         node client for dispatching to {@link DslExecuteAction}
+     * @param clusterService cluster service used to read and observe {@link #INTERCEPT_SEARCH_ENABLED}
      */
-    public SearchActionFilter(NodeClient client) {
+    public SearchActionFilter(NodeClient client, ClusterService clusterService) {
         this.client = client;
+        this.interceptEnabled = INTERCEPT_SEARCH_ENABLED.get(clusterService.getSettings());
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(INTERCEPT_SEARCH_ENABLED, value -> this.interceptEnabled = value);
     }
 
     @Override
@@ -57,7 +77,7 @@ public class SearchActionFilter implements ActionFilter {
     ) {
         // TODO: add support for other search-related APIs (_msearch, _count, _search_shards, etc.).
         // Consider two categories: APIs that execute search vs APIs that only explain/validate.
-        if (SearchAction.NAME.equals(action)) {
+        if (interceptEnabled && SearchAction.NAME.equals(action)) {
             SearchRequest searchRequest = (SearchRequest) request;
             client.execute(DslExecuteAction.INSTANCE, searchRequest, (ActionListener<SearchResponse>) listener);
         } else {

--- a/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
+++ b/sandbox/plugins/dsl-query-executor/src/test/java/org/opensearch/dsl/action/SearchActionFilterTests.java
@@ -15,17 +15,23 @@ import org.opensearch.action.search.SearchAction;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.node.NodeClient;
 
+import java.util.Set;
+
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 public class SearchActionFilterTests extends OpenSearchTestCase {
@@ -35,29 +41,50 @@ public class SearchActionFilterTests extends OpenSearchTestCase {
     private final ActionListener<ActionResponse> listener = mock(ActionListener.class);
     private final ActionFilterChain<ActionRequest, ActionResponse> chain = mock(ActionFilterChain.class);
     private final ActionRequestMetadata<ActionRequest, ActionResponse> metadata = mock(ActionRequestMetadata.class);
-    private final SearchActionFilter filter = new SearchActionFilter(client);
+
+    /**
+     * Builds a filter whose interception gate is initialised from a cluster service backed by the
+     * given setting value.
+     */
+    private SearchActionFilter newFilter(boolean interceptEnabled) {
+        Settings settings = Settings.builder()
+            .put(SearchActionFilter.INTERCEPT_SEARCH_ENABLED.getKey(), interceptEnabled)
+            .build();
+        ClusterSettings clusterSettings = new ClusterSettings(settings, Set.of(SearchActionFilter.INTERCEPT_SEARCH_ENABLED));
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        return new SearchActionFilter(client, clusterService);
+    }
 
     public void testOrderRunsAfterSecurityFilter() {
-        assertEquals(SearchActionFilter.FILTER_ORDER, filter.order());
+        assertEquals(SearchActionFilter.FILTER_ORDER, newFilter(true).order());
     }
 
     public void testPassesThroughNonSearchAction() {
         BulkRequest request = new BulkRequest();
 
-        filter.apply(task, BulkAction.NAME, request, metadata, listener, chain);
+        newFilter(true).apply(task, BulkAction.NAME, request, metadata, listener, chain);
 
         verify(chain).proceed(task, BulkAction.NAME, request, listener);
         verify(client, never()).execute(any(), any(), any());
     }
 
-    // TODO: add tests to verify reroute only happens when the target index has the setting enabled
-
-    public void testReroutesSearchAction() {
+    public void testReroutesSearchActionWhenInterceptEnabled() {
         SearchRequest request = new SearchRequest("test-index");
 
-        filter.apply(task, SearchAction.NAME, request, metadata, listener, chain);
+        newFilter(true).apply(task, SearchAction.NAME, request, metadata, listener, chain);
 
         verify(client).execute(eq(DslExecuteAction.INSTANCE), eq(request), any());
         verify(chain, never()).proceed(any(), any(), any(), any());
+    }
+
+    public void testPassesThroughSearchActionWhenInterceptDisabled() {
+        SearchRequest request = new SearchRequest("test-index");
+
+        newFilter(false).apply(task, SearchAction.NAME, request, metadata, listener, chain);
+
+        verify(chain).proceed(task, SearchAction.NAME, request, listener);
+        verify(client, never()).execute(any(), any(), any());
     }
 }

--- a/sandbox/plugins/parquet-data-format/build.gradle
+++ b/sandbox/plugins/parquet-data-format/build.gradle
@@ -22,6 +22,11 @@ dependencies {
   // Plugin stats SPI interfaces
   compileOnly project(":sandbox:libs:plugin-stats-spi")
 
+  // server provides Lucene (codecs, DocValues), MapperService/MappedFieldType, and the
+  // data-format framework SPI used by the DocValues codec (org.opensearch.parquet.codec).
+  compileOnly project(':server')
+  testImplementation project(':server')
+
   // Shared native bridge lib (provides the unified .so and FFM SymbolLookup)
   implementation project(':sandbox:libs:dataformat-native')
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
@@ -137,6 +137,14 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin,
         long mergeMax = ParquetSettings.MERGE_POOL_MAX.get(this.settings);
         RustBridge.initMemoryPools(writeMax, mergeMax);
 
+        // Enable the codec-owned cross-query decoded-page cache (liquid-cache core) when configured.
+        // Off by default → the DocValues decode path is unchanged.
+        boolean liquidCacheEnabled = ParquetSettings.LIQUID_CACHE_ENABLED.get(this.settings);
+        if (liquidCacheEnabled) {
+            long liquidCacheMaxBytes = ParquetSettings.LIQUID_CACHE_MAX_BYTES.get(this.settings).getBytes();
+            RustBridge.liquidCacheSetEnabled(true, liquidCacheMaxBytes);
+        }
+
         // Register virtual pools if allocator is available (arrow-base loaded)
         if (nativeAllocator != null) {
             NativeAllocator.VirtualPoolHandle writePool = nativeAllocator.registerVirtualPool(

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetDataFormatPlugin.java
@@ -28,6 +28,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.index.IndexCreationValidator;
+import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.engine.dataformat.DataFormat;
 import org.opensearch.index.engine.dataformat.DataFormatDescriptor;
@@ -38,6 +39,7 @@ import org.opensearch.index.engine.dataformat.IndexingExecutionEngine;
 import org.opensearch.index.engine.dataformat.StoreStrategy;
 import org.opensearch.index.store.PrecomputedChecksumStrategy;
 import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.codec.ParquetDocValuesDirectoryReader;
 import org.opensearch.parquet.engine.ParquetDataFormat;
 import org.opensearch.parquet.engine.ParquetIndexingEngine;
 import org.opensearch.parquet.fields.ArrowSchemaBuilder;
@@ -279,5 +281,28 @@ public class ParquetDataFormatPlugin extends Plugin implements DataFormatPlugin,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
         return List.of(new ParquetStatsRestAction(), new ParquetNodeStatsRestAction());
+    }
+
+    /**
+     * Installs the Parquet DocValues reader wrapper for indices backed by a pluggable data format.
+     *
+     * <p>The wrapper ({@link ParquetDocValuesDirectoryReader}) surfaces doc values for Parquet-resident
+     * fields that are absent from the Lucene segment, so standard aggregations, sorts, and scripts can
+     * read them through the normal Lucene read path — with no write-path change. It is gated to indices
+     * with {@code index.pluggable.dataformat.enabled} so non-composite indices are untouched.
+     *
+     * <p>The wrapper is a no-op per leaf when the mapping declares no missing Parquet-resident
+     * doc-values fields, so the per-request overhead for such segments is negligible.
+     */
+    @Override
+    public void onIndexModule(IndexModule indexModule) {
+        indexModule.setReaderWrapper(indexService -> {
+            // Gate to indices backed by a pluggable data format (the composite/Parquet path). For all
+            // other indices, return null so no wrapper is installed and the read path is untouched.
+            if (indexService.getIndexSettings().isPluggableDataFormatEnabled() == false) {
+                return null;
+            }
+            return reader -> ParquetDocValuesDirectoryReader.wrap(reader, indexService.mapperService());
+        });
     }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/ParquetSettings.java
@@ -218,6 +218,27 @@ public final class ParquetSettings {
     );
 
     /**
+     * Enables the codec-owned cross-query decoded-page cache (backed by liquid-cache core). When off
+     * (the default), the DocValues codec decode path is unchanged and the native cache is never
+     * consulted. Node-scoped: set in {@code opensearch.yml} or via {@code -E} at launch.
+     */
+    public static final Setting<Boolean> LIQUID_CACHE_ENABLED = Setting.boolSetting(
+        "parquet.liquid_cache.enabled",
+        false,
+        Setting.Property.NodeScope
+    );
+
+    /**
+     * Memory budget for the codec-owned decoded-page cache. A value of 0 leaves the native liquid
+     * default budget. Only consulted when {@link #LIQUID_CACHE_ENABLED} is true.
+     */
+    public static final Setting<ByteSizeValue> LIQUID_CACHE_MAX_BYTES = Setting.byteSizeSetting(
+        "parquet.liquid_cache.max_bytes",
+        new ByteSizeValue(0, ByteSizeUnit.BYTES),
+        Setting.Property.NodeScope
+    );
+
+    /**
      * Minimum number of variable-width (string/binary) non-sort columns required to activate
      * deferred data loading during merge. Below this threshold, all columns are decoded eagerly
      * (original behavior). Set to 0 to always defer; set very high to disable deferral.
@@ -849,6 +870,8 @@ public final class ParquetSettings {
             MERGE_BATCH_SIZE,
             MERGE_RAYON_THREADS,
             MERGE_IO_THREADS,
+            LIQUID_CACHE_ENABLED,
+            LIQUID_CACHE_MAX_BYTES,
             MERGE_DEFERRED_COLUMN_THRESHOLD,
             WRITE_POOL_MIN,
             WRITE_POOL_MAX,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/ParquetColumnReader.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/ParquetColumnReader.java
@@ -353,7 +353,12 @@ public final class ParquetColumnReader implements Closeable {
 
         long valueCap = (long) rows * ValueLayout.JAVA_LONG.byteSize();
         long offsetsCap = type.isPrimitive() ? 0 : (rows + 1);
-        MemorySegment valueBuf = bufferPool.bytes("pageValue", Math.max(valueCap, 1));
+        // Per-column value slot: for primitive columns the decoded segment is retained by the
+        // PageCache and read in place (zero-copy), so it must not be shared with another column's
+        // reader (which would overwrite it on its own decode). Presence/offsets stay shared —
+        // they are copied to the heap below.
+        final String valueSlot = "pageValue:" + column;
+        MemorySegment valueBuf = bufferPool.bytes(valueSlot, Math.max(valueCap, 1));
         MemorySegment offsets = type.isPrimitive() ? MemorySegment.NULL : bufferPool.ints("pageOffsets", offsetsCap);
         MemorySegment presence = bufferPool.longs("pagePresence", presenceWords);
 
@@ -381,7 +386,7 @@ public final class ParquetColumnReader implements Closeable {
 
             valueCap = Math.max(requiredValueBytes, 1);
             offsetsCap = type.isPrimitive() ? 0 : (actualRows + 1);
-            valueBuf = bufferPool.bytes("pageValue", valueCap);
+            valueBuf = bufferPool.bytes(valueSlot, valueCap);
             offsets = type.isPrimitive() ? MemorySegment.NULL : bufferPool.ints("pageOffsets", offsetsCap);
             presence = bufferPool.longs("pagePresence", actualPresenceWords);
 
@@ -416,7 +421,11 @@ public final class ParquetColumnReader implements Closeable {
             .toArray(ValueLayout.JAVA_LONG);
 
         if (type.isPrimitive()) {
-            pc.values = valueBuf.asSlice(0, (long) pageRows * ValueLayout.JAVA_LONG.byteSize()).toArray(ValueLayout.JAVA_LONG);
+            // Zero-copy: retain the off-heap segment (per-column slot) sliced to the page's
+            // longs; PageCache.valueAt reads it in place with no heap copy. Safe because this
+            // slot is not shared across columns and this column's next decode won't run until
+            // this cache is replaced.
+            pc.values = valueBuf.asSlice(0, (long) pageRows * ValueLayout.JAVA_LONG.byteSize());
         } else {
             pc.byteBuf = valueLen > 0 ? valueBuf.asSlice(0, valueLen).toArray(ValueLayout.JAVA_BYTE) : new byte[0];
             pc.byteOffsets = offsets.asSlice(0, (long) (pageRows + 1) * ValueLayout.JAVA_INT.byteSize()).toArray(ValueLayout.JAVA_INT);

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/ParquetColumnReader.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/ParquetColumnReader.java
@@ -1,0 +1,515 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.bridge;
+
+import org.opensearch.parquet.codec.ParquetPhysicalType;
+import org.opensearch.parquet.codec.cache.BufferPool;
+import org.opensearch.parquet.codec.cache.CacheStats;
+import org.opensearch.parquet.codec.cache.ColumnPageIndex;
+import org.opensearch.parquet.codec.cache.PageCache;
+import org.opensearch.parquet.codec.cache.QueryParquetStats;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+/**
+ * FFM wrapper over a single native Parquet column-reader handle, and the owner of that
+ * column's performance state (the Layer 3/4 {@link ColumnPageIndex} built at open, and the
+ * current Layer 1/2 {@link PageCache}).
+ *
+ * <p>This is the only class besides {@link RustBridge} that deals with the native
+ * column-reader surface; iterator implementations (task 5+) see only the plain-Java
+ * {@link PageCache} / {@link ColumnPageIndex} data structures.
+ *
+ * <p>Threading: a reader is single-threaded (one segment per query thread). It is not safe
+ * for concurrent use. {@link #close()} is idempotent.
+ *
+ * <p>Buffer ownership: scratch out-buffers handed to the native functions are drawn from a
+ * shared {@link BufferPool} (Layer 5). The slow-path reads and the page decode both follow
+ * the grow-and-retry overflow protocol: on {@link RustBridge#RC_OVERFLOW} the required sizes
+ * are read from the out-parameters, larger buffers are obtained from the pool, and the call
+ * is retried exactly once.
+ */
+public final class ParquetColumnReader implements Closeable {
+
+    private static final Logger logger = LogManager.getLogger(ParquetColumnReader.class);
+
+    /** Sentinel handle for a reader whose native handle has been released. */
+    private static final long CLOSED_HANDLE = -1L;
+
+    private final ParquetPhysicalType type;
+    private final boolean repeated;
+    private final BufferPool bufferPool;
+    private final Path file;
+    private final String column;
+    private final CacheStats stats = new CacheStats();
+
+    private long handle;
+    private ColumnPageIndex pageIndex;
+    private PageCache cache;
+
+    /** Optional per-query accumulator; this reader's {@link #stats} are folded in on {@link #close()}. */
+    private QueryParquetStats queryStats;
+
+    /** Nanoseconds in the native {@code openColumnReader} FFM call; flushed when query stats attach. */
+    private long openNanos;
+
+    private ParquetColumnReader(long handle, Path file, String column, ParquetPhysicalType type, boolean repeated, BufferPool bufferPool) {
+        this.handle = handle;
+        this.file = file;
+        this.column = column;
+        this.type = type;
+        this.repeated = repeated;
+        this.bufferPool = bufferPool;
+    }
+
+    /**
+     * Opens a column reader for {@code column} in the Parquet {@code file}, validating that
+     * the column exists and its physical type matches {@code expected}. Eagerly loads the
+     * column's {@link ColumnPageIndex} (Layer 3/4).
+     *
+     * @param repeated whether the column is multi-valued (max repetition level &gt; 0)
+     * @throws IOException if the file/column cannot be opened or the type mismatches
+     */
+    public static ParquetColumnReader open(Path file, String column, ParquetPhysicalType expected, boolean repeated, BufferPool pool)
+        throws IOException {
+        long openStart = System.nanoTime();
+        long h = RustBridge.openColumnReader(file.toString(), column, expected.code());
+        long openElapsed = System.nanoTime() - openStart;
+        ParquetColumnReader reader = new ParquetColumnReader(h, file, column, expected, repeated, pool);
+        reader.openNanos = openElapsed;
+        try {
+            long indexStart = System.nanoTime();
+            reader.pageIndex = reader.loadPageIndex();
+            reader.stats.addPageIndexLoadNanos(System.nanoTime() - indexStart);
+        } catch (IOException | RuntimeException e) {
+            // Never leak the native handle if page-index load fails after open.
+            reader.close();
+            throw e;
+        }
+        return reader;
+    }
+
+    /** The column's Parquet physical type. */
+    public ParquetPhysicalType type() {
+        return type;
+    }
+
+    /** Whether the column is multi-valued. */
+    public boolean isRepeated() {
+        return repeated;
+    }
+
+    /** The Layer 3/4 page index, loaded at {@link #open}. */
+    public ColumnPageIndex pageIndex() {
+        return pageIndex;
+    }
+
+    /** Per-column cache hit/miss counters across all caching layers (for diagnostics). */
+    public CacheStats stats() {
+        return stats;
+    }
+
+    /**
+     * Registers this reader's {@link #stats} with the per-query accumulator immediately, so the
+     * counters are summed live at end-of-query regardless of reader-close ordering. Optional; when
+     * unset (e.g. low-level tests) no roll-up happens.
+     */
+    public void setQueryStats(QueryParquetStats queryStats) {
+        this.queryStats = queryStats;
+        if (queryStats != null) {
+            queryStats.register(stats);
+            queryStats.addReaderOpenNanos(openNanos);
+        }
+    }
+
+    /**
+     * Returns the currently cached page, or {@code null} when no page is loaded or the last
+     * {@link #loadPageContaining(long)} landed on an all-nulls page (Layer 4 skip).
+     */
+    public PageCache cache() {
+        return cache;
+    }
+
+    // ── Slow-path single/repeated reads (used by ordinal-table construction, task 6) ──
+
+    /** Result of a single-valued read: whether the row had a value, and its raw {@code long} bits. */
+    public record Value(boolean present, long bits) {
+        public static final Value ABSENT = new Value(false, 0L);
+    }
+
+    /**
+     * Slow-path single-value read at global {@code row}. For primitive columns the returned
+     * {@code bits} are the raw value bits (INT32 sign-extended, FLOAT/DOUBLE via
+     * {@code *toRawBits}, BOOL as 0/1). For {@code BYTE_ARRAY} columns use
+     * {@link #readBytesAtRow(long)} instead.
+     */
+    public Value readValueAtRow(long row) throws IOException {
+        ensureOpen();
+        stats.slowValueRead();
+        long start = System.nanoTime();
+        try {
+            MemorySegment present = bufferPool.longOut("present");
+            MemorySegment longOut = bufferPool.longOut("long");
+            MemorySegment lenOut = bufferPool.longOut("len");
+            long rc = RustBridge.readValueAtRow(handle, row, present, longOut, MemorySegment.NULL, 0L, lenOut);
+            if (rc == RustBridge.RC_OVERFLOW) {
+                // Primitive reads never overflow (no byte payload); a BYTE_ARRAY column was
+                // queried through the primitive path.
+                throw new IOException("readValueAtRow: unexpected overflow for primitive read at row " + row);
+            }
+            boolean isPresent = present.get(ValueLayout.JAVA_LONG, 0) != 0L;
+            return isPresent ? new Value(true, longOut.get(ValueLayout.JAVA_LONG, 0)) : Value.ABSENT;
+        } finally {
+            stats.addSlowReadNanos(System.nanoTime() - start);
+        }
+    }
+
+    /**
+     * Slow-path single-value read of a {@code BYTE_ARRAY} column at global {@code row}.
+     * Returns the value bytes, or {@code null} when the row is null. Follows the
+     * grow-and-retry overflow protocol.
+     */
+    public byte[] readBytesAtRow(long row) throws IOException {
+        ensureOpen();
+        stats.slowValueRead();
+        long start = System.nanoTime();
+        try {
+            MemorySegment present = bufferPool.longOut("present");
+            MemorySegment longOut = bufferPool.longOut("long");
+            MemorySegment lenOut = bufferPool.longOut("len");
+
+            long cap = 64;
+            MemorySegment buf = bufferPool.bytes("value", cap);
+            long rc = RustBridge.readValueAtRow(handle, row, present, longOut, buf, cap, lenOut);
+            if (rc == RustBridge.RC_OVERFLOW) {
+                long required = lenOut.get(ValueLayout.JAVA_LONG, 0);
+                buf = bufferPool.bytes("value", required);
+                cap = required;
+                rc = RustBridge.readValueAtRow(handle, row, present, longOut, buf, cap, lenOut);
+                if (rc == RustBridge.RC_OVERFLOW) {
+                    throw new IOException("readBytesAtRow: overflow persisted after retry at row " + row);
+                }
+            }
+            if (present.get(ValueLayout.JAVA_LONG, 0) == 0L) {
+                return null;
+            }
+            long len = lenOut.get(ValueLayout.JAVA_LONG, 0);
+            if (len < 0) {
+                return null;
+            }
+            return buf.asSlice(0, len).toArray(ValueLayout.JAVA_BYTE);
+        } finally {
+            stats.addSlowReadNanos(System.nanoTime() - start);
+        }
+    }
+
+    /** Result of a repeated primitive read: the per-value raw {@code long} bits, in row order. */
+    public record RepeatedValues(long[] bits) {
+        public static final RepeatedValues EMPTY = new RepeatedValues(new long[0]);
+
+        public int count() {
+            return bits.length;
+        }
+    }
+
+    /**
+     * Slow-path repeated read of a primitive column at global {@code row}. Returns the raw
+     * {@code long} bits of each repeated value, in row order. Follows the grow-and-retry
+     * overflow protocol.
+     */
+    public RepeatedValues readRepeatedAtRow(long row) throws IOException {
+        ensureOpen();
+        stats.slowRepeatedRead();
+        long start = System.nanoTime();
+        try {
+            MemorySegment countOut = bufferPool.longOut("count");
+
+            long cap = 8;
+            MemorySegment longs = bufferPool.longs("repeated", cap);
+            long rc = RustBridge.readRepeatedAtRow(handle, row, countOut, longs, cap, MemorySegment.NULL, MemorySegment.NULL, 0L);
+            if (rc == RustBridge.RC_OVERFLOW) {
+                long required = countOut.get(ValueLayout.JAVA_LONG, 0);
+                longs = bufferPool.longs("repeated", required);
+                cap = required;
+                rc = RustBridge.readRepeatedAtRow(handle, row, countOut, longs, cap, MemorySegment.NULL, MemorySegment.NULL, 0L);
+                if (rc == RustBridge.RC_OVERFLOW) {
+                    throw new IOException("readRepeatedAtRow: overflow persisted after retry at row " + row);
+                }
+            }
+            int count = (int) countOut.get(ValueLayout.JAVA_LONG, 0);
+            if (count == 0) {
+                return RepeatedValues.EMPTY;
+            }
+            long[] out = longs.asSlice(0, (long) count * ValueLayout.JAVA_LONG.byteSize()).toArray(ValueLayout.JAVA_LONG);
+            return new RepeatedValues(out);
+        } finally {
+            stats.addSlowReadNanos(System.nanoTime() - start);
+        }
+    }
+
+    /**
+     * Slow-path repeated read of a {@code BYTE_ARRAY} column at global {@code row}. Returns one
+     * {@code byte[]} per repeated value in row order, or {@code null} when the row's list is
+     * empty. Follows the grow-and-retry overflow protocol for both the element-count buffer
+     * and the concatenated-bytes buffer.
+     */
+    public byte[][] readRepeatedBytesAtRow(long row) throws IOException {
+        ensureOpen();
+        stats.slowRepeatedRead();
+        long startNanos = System.nanoTime();
+        try {
+            MemorySegment countOut = bufferPool.longOut("count");
+
+            long countCap = 8;
+            long byteCap = 256;
+            MemorySegment offsets = bufferPool.longs("repeatedOffsets", countCap + 1);
+            MemorySegment byteBuf = bufferPool.bytes("repeatedBytes", byteCap);
+
+            long rc = RustBridge.readRepeatedAtRow(handle, row, countOut, MemorySegment.NULL, countCap, byteBuf, offsets, byteCap);
+            if (rc == RustBridge.RC_OVERFLOW) {
+                long requiredCount = countOut.get(ValueLayout.JAVA_LONG, 0);
+                countCap = Math.max(requiredCount, countCap);
+                offsets = bufferPool.longs("repeatedOffsets", countCap + 1);
+                // First retry establishes the offsets so we can learn the required byte size.
+                rc = RustBridge.readRepeatedAtRow(handle, row, countOut, MemorySegment.NULL, countCap, byteBuf, offsets, byteCap);
+                if (rc == RustBridge.RC_OVERFLOW) {
+                    // Byte buffer too small: offsets[count] reports the required total byte size.
+                    int cnt = (int) countOut.get(ValueLayout.JAVA_LONG, 0);
+                    long requiredBytes = offsets.getAtIndex(ValueLayout.JAVA_LONG, cnt);
+                    byteCap = Math.max(requiredBytes, byteCap);
+                    byteBuf = bufferPool.bytes("repeatedBytes", byteCap);
+                    rc = RustBridge.readRepeatedAtRow(handle, row, countOut, MemorySegment.NULL, countCap, byteBuf, offsets, byteCap);
+                    if (rc == RustBridge.RC_OVERFLOW) {
+                        throw new IOException("readRepeatedBytesAtRow: overflow persisted after retry at row " + row);
+                    }
+                }
+            }
+
+            int count = (int) countOut.get(ValueLayout.JAVA_LONG, 0);
+            if (count == 0) {
+                return null;
+            }
+            byte[][] out = new byte[count][];
+            for (int i = 0; i < count; i++) {
+                int start = (int) offsets.getAtIndex(ValueLayout.JAVA_LONG, i);
+                int end = (int) offsets.getAtIndex(ValueLayout.JAVA_LONG, i + 1);
+                out[i] = byteBuf.asSlice(start, (long) (end - start)).toArray(ValueLayout.JAVA_BYTE);
+            }
+            return out;
+        } finally {
+            stats.addSlowReadNanos(System.nanoTime() - startNanos);
+        }
+    }
+
+    // ── Page index + page decode (Layer 1-4 hot path) ──
+
+    /**
+     * Loads the page that contains global {@code row} into the cache (Layer 1/2), applying
+     * the Layer 4 all-nulls skip first. On an all-nulls page the cache is set to {@code null}
+     * and no decode happens. Single-valued columns only; repeated columns use the slow path.
+     */
+    public void loadPageContaining(long row) throws IOException {
+        ensureOpen();
+        // Layer 3 — OffsetIndex jump-table lookup (consulted on every page miss).
+        stats.pageIndexLookup();
+        int pageIdx = pageIndex.pageForRow(row);
+        if (pageIdx < 0) {
+            throw new IOException("loadPageContaining: row " + row + " out of range (rows " + pageIndex.totalRows() + ")");
+        }
+        if (pageIndex.isAllNulls(pageIdx)) {
+            // Layer 4 — whole page is null, resolved with no decode.
+            stats.allNullPageSkip();
+            cache = null; // Layer 4 — whole page is null, no decode.
+            return;
+        }
+        // FFM — page decode crossing.
+        stats.pageDecode();
+        cache = decodePage(row);
+    }
+
+    private PageCache decodePage(long row) throws IOException {
+        MemorySegment firstRowOut = bufferPool.longOut("firstRow");
+        MemorySegment lastRowOut = bufferPool.longOut("lastRow");
+        MemorySegment valueLenOut = bufferPool.longOut("valueLen");
+
+        // Size the page from the index so the first attempt usually fits.
+        int pageIdx = pageIndex.pageForRow(row);
+        int rows = (int) pageIndex.numRowsOf(pageIdx);
+        int presenceWords = (rows + 63) >>> 6;
+
+        long valueCap = (long) rows * ValueLayout.JAVA_LONG.byteSize();
+        long offsetsCap = type.isPrimitive() ? 0 : (rows + 1);
+        MemorySegment valueBuf = bufferPool.bytes("pageValue", Math.max(valueCap, 1));
+        MemorySegment offsets = type.isPrimitive() ? MemorySegment.NULL : bufferPool.ints("pageOffsets", offsetsCap);
+        MemorySegment presence = bufferPool.longs("pagePresence", presenceWords);
+
+        long rc = RustBridge.decodePageAtRow(
+            handle,
+            row,
+            firstRowOut,
+            lastRowOut,
+            valueBuf,
+            valueCap,
+            valueLenOut,
+            offsets,
+            offsetsCap,
+            presence,
+            presenceWords
+        );
+
+        if (rc == RustBridge.RC_OVERFLOW) {
+            // Re-size from the reported page range + value length and retry once.
+            long fr = firstRowOut.get(ValueLayout.JAVA_LONG, 0);
+            long lr = lastRowOut.get(ValueLayout.JAVA_LONG, 0);
+            int actualRows = (int) (lr - fr + 1);
+            int actualPresenceWords = (actualRows + 63) >>> 6;
+            long requiredValueBytes = valueLenOut.get(ValueLayout.JAVA_LONG, 0);
+
+            valueCap = Math.max(requiredValueBytes, 1);
+            offsetsCap = type.isPrimitive() ? 0 : (actualRows + 1);
+            valueBuf = bufferPool.bytes("pageValue", valueCap);
+            offsets = type.isPrimitive() ? MemorySegment.NULL : bufferPool.ints("pageOffsets", offsetsCap);
+            presence = bufferPool.longs("pagePresence", actualPresenceWords);
+
+            rc = RustBridge.decodePageAtRow(
+                handle,
+                row,
+                firstRowOut,
+                lastRowOut,
+                valueBuf,
+                valueCap,
+                valueLenOut,
+                offsets,
+                offsetsCap,
+                presence,
+                actualPresenceWords
+            );
+            if (rc == RustBridge.RC_OVERFLOW) {
+                throw new IOException("decodePageAtRow: overflow persisted after retry at row " + row);
+            }
+            presenceWords = actualPresenceWords;
+        }
+
+        long firstRow = firstRowOut.get(ValueLayout.JAVA_LONG, 0);
+        long lastRow = lastRowOut.get(ValueLayout.JAVA_LONG, 0);
+        long valueLen = valueLenOut.get(ValueLayout.JAVA_LONG, 0);
+        int pageRows = (int) (lastRow - firstRow + 1);
+
+        PageCache pc = new PageCache();
+        pc.firstRow = firstRow;
+        pc.lastRow = lastRow;
+        pc.presenceBits = presence.asSlice(0, (long) ((pageRows + 63) >>> 6) * ValueLayout.JAVA_LONG.byteSize())
+            .toArray(ValueLayout.JAVA_LONG);
+
+        if (type.isPrimitive()) {
+            pc.values = valueBuf.asSlice(0, (long) pageRows * ValueLayout.JAVA_LONG.byteSize()).toArray(ValueLayout.JAVA_LONG);
+        } else {
+            pc.byteBuf = valueLen > 0 ? valueBuf.asSlice(0, valueLen).toArray(ValueLayout.JAVA_BYTE) : new byte[0];
+            pc.byteOffsets = offsets.asSlice(0, (long) (pageRows + 1) * ValueLayout.JAVA_INT.byteSize()).toArray(ValueLayout.JAVA_INT);
+        }
+        return pc;
+    }
+
+    private ColumnPageIndex loadPageIndex() throws IOException {
+        long numPages = RustBridge.getColumnNumPages(handle);
+        int n = Math.toIntExact(numPages);
+
+        MemorySegment firstRow = bufferPool.longs("idxFirstRow", Math.max(n, 1));
+        MemorySegment fileOffset = bufferPool.longs("idxFileOffset", Math.max(n, 1));
+        MemorySegment compressed = bufferPool.ints("idxCompressed", Math.max(n, 1));
+        MemorySegment nullCount = bufferPool.longs("idxNullCount", Math.max(n, 1));
+        MemorySegment minLong = bufferPool.longs("idxMin", Math.max(n, 1));
+        MemorySegment maxLong = bufferPool.longs("idxMax", Math.max(n, 1));
+        MemorySegment actualPages = bufferPool.longOut("idxActualPages");
+
+        long rc = RustBridge.getColumnPageIndex(handle, firstRow, fileOffset, compressed, nullCount, minLong, maxLong, n, actualPages);
+        if (rc == RustBridge.RC_OVERFLOW) {
+            // Page count grew between the two calls (shouldn't happen for an immutable
+            // file, but handle defensively): re-size to the reported count and retry once.
+            n = Math.toIntExact(actualPages.get(ValueLayout.JAVA_LONG, 0));
+            firstRow = bufferPool.longs("idxFirstRow", Math.max(n, 1));
+            fileOffset = bufferPool.longs("idxFileOffset", Math.max(n, 1));
+            compressed = bufferPool.ints("idxCompressed", Math.max(n, 1));
+            nullCount = bufferPool.longs("idxNullCount", Math.max(n, 1));
+            minLong = bufferPool.longs("idxMin", Math.max(n, 1));
+            maxLong = bufferPool.longs("idxMax", Math.max(n, 1));
+            rc = RustBridge.getColumnPageIndex(handle, firstRow, fileOffset, compressed, nullCount, minLong, maxLong, n, actualPages);
+            if (rc == RustBridge.RC_OVERFLOW) {
+                throw new IOException("getColumnPageIndex: overflow persisted after retry");
+            }
+        }
+
+        long[] firstRowArr = toLongArray(firstRow, n);
+        long[] fileOffsetArr = toLongArray(fileOffset, n);
+        int[] compressedArr = toIntArray(compressed, n);
+        long[] nullCountArr = toLongArray(nullCount, n);
+        long[] minArr = toLongArray(minLong, n);
+        long[] maxArr = toLongArray(maxLong, n);
+
+        // The per-page first-row offsets don't encode the last page's length, so take the
+        // file's authoritative row count from metadata. open() is invoked once per column,
+        // so this extra metadata read is not on the hot path.
+        long totalRows = RustBridge.getFileMetadata(file.toString()).numRows();
+        return new ColumnPageIndex(firstRowArr, fileOffsetArr, compressedArr, nullCountArr, minArr, maxArr, totalRows);
+    }
+
+    private static long[] toLongArray(MemorySegment seg, int n) {
+        if (n == 0) {
+            return new long[0];
+        }
+        return seg.asSlice(0, (long) n * ValueLayout.JAVA_LONG.byteSize()).toArray(ValueLayout.JAVA_LONG);
+    }
+
+    private static int[] toIntArray(MemorySegment seg, int n) {
+        if (n == 0) {
+            return new int[0];
+        }
+        return seg.asSlice(0, (long) n * ValueLayout.JAVA_INT.byteSize()).toArray(ValueLayout.JAVA_INT);
+    }
+
+    /** Decodes a UTF-8 byte slice from the binary page cache. */
+    public static String utf8(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private void ensureOpen() {
+        if (handle == CLOSED_HANDLE) {
+            throw new IllegalStateException("ParquetColumnReader is closed");
+        }
+    }
+
+    /** Idempotent: releases the native handle exactly once; never leaks on repeated calls. */
+    @Override
+    public void close() throws IOException {
+        if (handle == CLOSED_HANDLE) {
+            return;
+        }
+        // Per-query roll-up is handled by registration at open (see setQueryStats); here we only emit
+        // the per-column detail at DEBUG for deep dives.
+        if (stats.isEmpty() == false && logger.isDebugEnabled()) {
+            logger.debug("[PARQUET_DV_CACHE_STATS] col='{}' file={} | {}", column, file, stats.summary());
+        }
+        long h = handle;
+        handle = CLOSED_HANDLE;
+        cache = null;
+        long closeStart = System.nanoTime();
+        RustBridge.closeColumnReader(h);
+        if (queryStats != null) {
+            queryStats.addReaderCloseNanos(System.nanoTime() - closeStart);
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/ParquetColumnReader.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/ParquetColumnReader.java
@@ -24,6 +24,9 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * FFM wrapper over a single native Parquet column-reader handle, and the owner of that
@@ -66,6 +69,43 @@ public final class ParquetColumnReader implements Closeable {
 
     /** Nanoseconds in the native {@code openColumnReader} FFM call; flushed when query stats attach. */
     private long openNanos;
+
+    // ── Prefetch state ──
+    // Shared daemon executor (2 threads); bounded because each decode is ~100µs — more threads
+    // would just contend on the per-handle mutex. Daemon so plugin reload doesn't hang.
+    private static final ExecutorService PREFETCH_EXECUTOR = Executors.newFixedThreadPool(2, r -> {
+        Thread t = new Thread(r, "parquet-dv-prefetch");
+        t.setDaemon(true);
+        return t;
+    });
+
+    /** Page index of the last decoded page (for sequential detection). -1 = no previous decode. */
+    private int lastDecodedPageIdx = -1;
+    /** Whether the access pattern is detected as sequential (at least two consecutive page misses). */
+    private boolean sequential;
+    /** In-flight prefetch; null when idle. */
+    private Future<PageCache> pendingPrefetch;
+    /** The page index the pending prefetch is decoding. -1 if none. */
+    private int prefetchPageIdx = -1;
+    /**
+     * Ping-pong buffer generation per lane. Within each lane the generation flips per decode
+     * so a value segment retained zero-copy by the live {@link PageCache} is not overwritten
+     * by that lane's next decode while it is still being read. Two generations suffice: at
+     * most one page per lane is live at a time (one adopted cache + one in-flight prefetch).
+     */
+    private int queryGen;
+    private int prefetchGen;
+
+    /**
+     * Dedicated buffer pool for the prefetch thread. Critical: {@link BufferPool} holds an
+     * unsynchronized {@code HashMap} and (re)allocates from its Arena on growth — so the query
+     * thread and prefetch thread must NEVER call into the same pool concurrently, or the map
+     * resize races and a lookup returns the wrong segment (observed as non-deterministic decoded
+     * values). Isolating the prefetch to its own pool removes all shared mutable state; the
+     * adopted PageCache's segment is only ever read cross-thread, which the shared Arena allows.
+     * Lazily created (only sequential scans prefetch) and closed with the reader.
+     */
+    private volatile BufferPool prefetchPool;
 
     private ParquetColumnReader(long handle, Path file, String column, ParquetPhysicalType type, boolean repeated, BufferPool bufferPool) {
         this.handle = handle;
@@ -321,6 +361,10 @@ public final class ParquetColumnReader implements Closeable {
      * Loads the page that contains global {@code row} into the cache (Layer 1/2), applying
      * the Layer 4 all-nulls skip first. On an all-nulls page the cache is set to {@code null}
      * and no decode happens. Single-valued columns only; repeated columns use the slow path.
+     *
+     * <p><b>Prefetch:</b> when access is sequential, the previous call's decode kicked off an
+     * async prefetch of the next page. If that prefetch covers this row, it's adopted directly
+     * (zero FFM on this call). Otherwise the prefetch result is discarded and a sync decode runs.
      */
     public void loadPageContaining(long row) throws IOException {
         ensureOpen();
@@ -331,36 +375,132 @@ public final class ParquetColumnReader implements Closeable {
             throw new IOException("loadPageContaining: row " + row + " out of range (rows " + pageIndex.totalRows() + ")");
         }
         if (pageIndex.isAllNulls(pageIdx)) {
-            // Layer 4 — whole page is null, resolved with no decode.
             stats.allNullPageSkip();
-            cache = null; // Layer 4 — whole page is null, no decode.
+            cache = null;
+            discardPrefetch();
+            updateSequentialState(pageIdx);
             return;
         }
-        // FFM — page decode crossing.
+
+        // Try to adopt a landed prefetch for this page.
+        if (pendingPrefetch != null && prefetchPageIdx == pageIdx) {
+            try {
+                PageCache prefetched = pendingPrefetch.get();
+                if (prefetched != null) {
+                    cache = prefetched;
+                    stats.prefetchHit();
+                    pendingPrefetch = null;
+                    prefetchPageIdx = -1;
+                    updateSequentialState(pageIdx);
+                    submitPrefetchIfSequential(pageIdx);
+                    return;
+                }
+            } catch (Exception e) {
+                logger.debug("[PARQUET_DV_PREFETCH] prefetch failed for page {}: {}", pageIdx, e.getMessage());
+            }
+            pendingPrefetch = null;
+            prefetchPageIdx = -1;
+        } else if (pendingPrefetch != null) {
+            // Prefetch was for a different page — access jumped, discard it.
+            discardPrefetch();
+        }
+
+        // Sync decode — the normal path.
         stats.pageDecode();
         cache = decodePage(row);
+        updateSequentialState(pageIdx);
+        submitPrefetchIfSequential(pageIdx);
     }
 
+    private void updateSequentialState(int pageIdx) {
+        sequential = (lastDecodedPageIdx >= 0 && pageIdx == lastDecodedPageIdx + 1);
+        lastDecodedPageIdx = pageIdx;
+    }
+
+    private void submitPrefetchIfSequential(int currentPageIdx) {
+        if (sequential == false) {
+            return;
+        }
+        int nextPageIdx = currentPageIdx + 1;
+        if (nextPageIdx >= pageIndex.pageCount()) {
+            return;
+        }
+        if (pageIndex.isAllNulls(nextPageIdx)) {
+            return;
+        }
+        long nextFirstRow = pageIndex.firstRowOf(nextPageIdx);
+        if (prefetchPool == null) {
+            prefetchPool = new BufferPool();
+        }
+        stats.prefetchSubmitted();
+        prefetchPageIdx = nextPageIdx;
+        pendingPrefetch = PREFETCH_EXECUTOR.submit(() -> {
+            try {
+                return decodePagePrefetch(nextFirstRow);
+            } catch (Exception e) {
+                logger.debug("[PARQUET_DV_PREFETCH] async decode failed: {}", e.getMessage());
+                return null;
+            }
+        });
+    }
+
+    private void discardPrefetch() {
+        if (pendingPrefetch != null) {
+            stats.prefetchWaste();
+            pendingPrefetch.cancel(false);
+            pendingPrefetch = null;
+            prefetchPageIdx = -1;
+        }
+    }
+
+    /**
+     * Decode used by the query thread. Uses buffer slot generation {@code gen} so that a
+     * value segment retained zero-copy by the current {@link PageCache} is never the one the
+     * next (prefetch or sync) decode writes into. The query path and prefetch path also use
+     * disjoint scratch slots (see {@code slot()}), so an in-flight prefetch on the background
+     * thread cannot race the query thread's own out-buffers.
+     */
     private PageCache decodePage(long row) throws IOException {
-        MemorySegment firstRowOut = bufferPool.longOut("firstRow");
-        MemorySegment lastRowOut = bufferPool.longOut("lastRow");
-        MemorySegment valueLenOut = bufferPool.longOut("valueLen");
+        // Ping-pong the query-thread value buffer so this decode does not overwrite the
+        // segment the previous cache (possibly still being read) holds.
+        queryGen ^= 1;
+        return decodePageInto(row, bufferPool, "q", queryGen);
+    }
+
+    /**
+     * Decode used by the prefetch thread. Uses a DEDICATED {@link BufferPool} so it never
+     * touches the query thread's pool concurrently (the pool's HashMap/Arena growth is not
+     * thread-safe). Still ping-pongs its own generation so a prefetched-then-adopted segment
+     * isn't overwritten by the following prefetch while the query thread reads it.
+     */
+    private PageCache decodePagePrefetch(long row) throws IOException {
+        prefetchGen ^= 1;
+        return decodePageInto(row, prefetchPool, "p", prefetchGen);
+    }
+
+    /** Per-purpose, per-lane, per-generation slot name — guarantees no two live pages collide. */
+    private String slot(String lane, int gen, String purpose) {
+        return purpose + ":" + lane + gen + ":" + column;
+    }
+
+    private PageCache decodePageInto(long row, BufferPool pool, String lane, int gen) throws IOException {
+        MemorySegment firstRowOut = pool.longOut(slot(lane, gen, "firstRow"));
+        MemorySegment lastRowOut = pool.longOut(slot(lane, gen, "lastRow"));
+        MemorySegment valueLenOut = pool.longOut(slot(lane, gen, "valueLen"));
+        String valueSlot = slot(lane, gen, "pageValue");
 
         // Size the page from the index so the first attempt usually fits.
         int pageIdx = pageIndex.pageForRow(row);
         int rows = (int) pageIndex.numRowsOf(pageIdx);
         int presenceWords = (rows + 63) >>> 6;
 
+        String offsetsSlot = slot(lane, gen, "pageOffsets");
+        String presenceSlot = slot(lane, gen, "pagePresence");
         long valueCap = (long) rows * ValueLayout.JAVA_LONG.byteSize();
         long offsetsCap = type.isPrimitive() ? 0 : (rows + 1);
-        // Per-column value slot: for primitive columns the decoded segment is retained by the
-        // PageCache and read in place (zero-copy), so it must not be shared with another column's
-        // reader (which would overwrite it on its own decode). Presence/offsets stay shared —
-        // they are copied to the heap below.
-        final String valueSlot = "pageValue:" + column;
-        MemorySegment valueBuf = bufferPool.bytes(valueSlot, Math.max(valueCap, 1));
-        MemorySegment offsets = type.isPrimitive() ? MemorySegment.NULL : bufferPool.ints("pageOffsets", offsetsCap);
-        MemorySegment presence = bufferPool.longs("pagePresence", presenceWords);
+        MemorySegment valueBuf = pool.bytes(valueSlot, Math.max(valueCap, 1));
+        MemorySegment offsets = type.isPrimitive() ? MemorySegment.NULL : pool.ints(offsetsSlot, offsetsCap);
+        MemorySegment presence = pool.longs(presenceSlot, presenceWords);
 
         long rc = RustBridge.decodePageAtRow(
             handle,
@@ -386,9 +526,9 @@ public final class ParquetColumnReader implements Closeable {
 
             valueCap = Math.max(requiredValueBytes, 1);
             offsetsCap = type.isPrimitive() ? 0 : (actualRows + 1);
-            valueBuf = bufferPool.bytes(valueSlot, valueCap);
-            offsets = type.isPrimitive() ? MemorySegment.NULL : bufferPool.ints("pageOffsets", offsetsCap);
-            presence = bufferPool.longs("pagePresence", actualPresenceWords);
+            valueBuf = pool.bytes(valueSlot, valueCap);
+            offsets = type.isPrimitive() ? MemorySegment.NULL : pool.ints(offsetsSlot, offsetsCap);
+            presence = pool.longs(presenceSlot, actualPresenceWords);
 
             rc = RustBridge.decodePageAtRow(
                 handle,
@@ -506,6 +646,20 @@ public final class ParquetColumnReader implements Closeable {
     public void close() throws IOException {
         if (handle == CLOSED_HANDLE) {
             return;
+        }
+        // Join any in-flight prefetch before releasing buffers and the native handle — the
+        // prefetch thread may be writing into a shared-arena segment that close() would free.
+        if (pendingPrefetch != null) {
+            try {
+                pendingPrefetch.get();
+            } catch (Exception ignored) {}
+            pendingPrefetch = null;
+            prefetchPageIdx = -1;
+        }
+        // Close the prefetch pool only after its last decode has joined above.
+        if (prefetchPool != null) {
+            prefetchPool.close();
+            prefetchPool = null;
         }
         // Per-query roll-up is handled by registration at open (see setQueryStats); here we only emit
         // the per-column detail at DEBUG for deep dives.

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -56,6 +56,7 @@ public class RustBridge {
     private static final MethodHandle CLOSE_COLUMN_READER;
     private static final MethodHandle OPEN_COLUMN_READER_COUNT;
     private static final MethodHandle LIQUID_CACHE_SET_ENABLED;
+    private static final MethodHandle LIQUID_CACHE_STATS;
     private static final MethodHandle READ_VALUE_AT_ROW;
     private static final MethodHandle READ_REPEATED_AT_ROW;
     private static final MethodHandle GET_COLUMN_NUM_PAGES;
@@ -322,6 +323,10 @@ public class RustBridge {
         LIQUID_CACHE_SET_ENABLED = linker.downcallHandle(
             lib.find("parquet_liquid_cache_set_enabled").orElseThrow(),
             FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG)
+        );
+        LIQUID_CACHE_STATS = linker.downcallHandle(
+            lib.find("parquet_liquid_cache_stats").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG)
         );
         READ_VALUE_AT_ROW = linker.downcallHandle(
             lib.find("parquet_read_value_at_row").orElseThrow(),
@@ -865,6 +870,23 @@ public class RustBridge {
      */
     public static void liquidCacheSetEnabled(boolean enabled, long maxMemoryBytes) {
         NativeCall.invokeVoid(LIQUID_CACHE_SET_ENABLED, enabled ? 1 : 0, maxMemoryBytes);
+    }
+
+    /**
+     * Returns the codec liquid page-cache counters {@code [hits, misses, backfills]}, so callers
+     * can confirm the cache is actually serving hits (a "liquid-on" run that is all misses tells
+     * you nothing about the hit path). Process-global, cumulative since JVM start.
+     */
+    public static long[] liquidCacheStats() {
+        try (var call = new NativeCall()) {
+            var buf = call.buf(3 * 8);
+            long n = NativeCall.invokeStatic(LIQUID_CACHE_STATS, buf, 3L);
+            long[] all = buf.toArray(ValueLayout.JAVA_LONG);
+            if (n < 3) {
+                return new long[] { 0, 0, 0 };
+            }
+            return all;
+        }
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -51,6 +51,25 @@ public class RustBridge {
     private static final MethodHandle SET_MERGE_POOL_LIMIT;
     private static final MethodHandle GET_POOL_STATS;
 
+    // DocValues codec — column-reader functions (tasks 1.1 + 1.2)
+    private static final MethodHandle OPEN_COLUMN_READER;
+    private static final MethodHandle CLOSE_COLUMN_READER;
+    private static final MethodHandle OPEN_COLUMN_READER_COUNT;
+    private static final MethodHandle READ_VALUE_AT_ROW;
+    private static final MethodHandle READ_REPEATED_AT_ROW;
+    private static final MethodHandle GET_COLUMN_NUM_PAGES;
+    private static final MethodHandle GET_COLUMN_PAGE_INDEX;
+    private static final MethodHandle DECODE_PAGE_AT_ROW;
+
+    /**
+     * Positive status code returned by the column-reader read/decode functions
+     * when a caller out-buffer was too small. The required sizes are written to
+     * the out-parameters so the caller can grow its buffers and retry once. This
+     * is distinct from the {@code < 0} error-pointer convention (a small negative
+     * constant would be dereferenced as an error pointer and corrupt memory).
+     */
+    public static final long RC_OVERFLOW = 1L;
+
     static {
         SymbolLookup lib = NativeLibraryLoader.symbolLookup();
         Linker linker = Linker.nativeLinker();
@@ -277,6 +296,90 @@ public class RustBridge {
         GET_POOL_STATS = linker.downcallHandle(
             lib.find("parquet_get_pool_stats").orElseThrow(),
             FunctionDescriptor.ofVoid(ValueLayout.ADDRESS)
+        );
+
+        // ── DocValues codec column-reader functions ──
+        OPEN_COLUMN_READER = linker.downcallHandle(
+            lib.find("parquet_open_column_reader").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,    // file_ptr
+                ValueLayout.JAVA_LONG,  // file_len
+                ValueLayout.ADDRESS,    // col_ptr
+                ValueLayout.JAVA_LONG,  // col_len
+                ValueLayout.JAVA_INT    // expected_type
+            )
+        );
+        CLOSE_COLUMN_READER = linker.downcallHandle(
+            lib.find("parquet_close_column_reader").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+        OPEN_COLUMN_READER_COUNT = linker.downcallHandle(
+            lib.find("parquet_open_column_reader_count").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG)
+        );
+        READ_VALUE_AT_ROW = linker.downcallHandle(
+            lib.find("parquet_read_value_at_row").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,  // handle
+                ValueLayout.JAVA_LONG,  // row
+                ValueLayout.ADDRESS,    // out_present
+                ValueLayout.ADDRESS,    // out_long
+                ValueLayout.ADDRESS,    // out_buf
+                ValueLayout.JAVA_LONG,  // out_buf_cap
+                ValueLayout.ADDRESS     // out_len
+            )
+        );
+        READ_REPEATED_AT_ROW = linker.downcallHandle(
+            lib.find("parquet_read_repeated_at_row").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,  // handle
+                ValueLayout.JAVA_LONG,  // row
+                ValueLayout.ADDRESS,    // out_count
+                ValueLayout.ADDRESS,    // out_longs
+                ValueLayout.JAVA_LONG,  // out_long_cap
+                ValueLayout.ADDRESS,    // out_byte_buf
+                ValueLayout.ADDRESS,    // out_byte_offsets
+                ValueLayout.JAVA_LONG   // out_byte_buf_cap
+            )
+        );
+        GET_COLUMN_NUM_PAGES = linker.downcallHandle(
+            lib.find("parquet_get_column_num_pages").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+        GET_COLUMN_PAGE_INDEX = linker.downcallHandle(
+            lib.find("parquet_get_column_page_index").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,  // handle
+                ValueLayout.ADDRESS,    // out_first_row
+                ValueLayout.ADDRESS,    // out_file_offset
+                ValueLayout.ADDRESS,    // out_compressed_size
+                ValueLayout.ADDRESS,    // out_null_count
+                ValueLayout.ADDRESS,    // out_min_long
+                ValueLayout.ADDRESS,    // out_max_long
+                ValueLayout.JAVA_LONG,  // out_buf_capacity
+                ValueLayout.ADDRESS     // out_actual_pages
+            )
+        );
+        DECODE_PAGE_AT_ROW = linker.downcallHandle(
+            lib.find("parquet_decode_page_at_row").orElseThrow(),
+            FunctionDescriptor.of(
+                ValueLayout.JAVA_LONG,
+                ValueLayout.JAVA_LONG,  // handle
+                ValueLayout.JAVA_LONG,  // row
+                ValueLayout.ADDRESS,    // out_first_row
+                ValueLayout.ADDRESS,    // out_last_row
+                ValueLayout.ADDRESS,    // out_value_buf
+                ValueLayout.JAVA_LONG,  // out_value_buf_cap
+                ValueLayout.ADDRESS,    // out_value_actual_len
+                ValueLayout.ADDRESS,    // out_byte_offsets
+                ValueLayout.JAVA_LONG,  // out_byte_offsets_cap
+                ValueLayout.ADDRESS,    // out_presence_bitset
+                ValueLayout.JAVA_LONG   // out_presence_bits_cap
+            )
         );
     }
 
@@ -687,6 +790,173 @@ public class RustBridge {
             int len = (int) outLen.get(ValueLayout.JAVA_LONG, 0);
             return new String(outBuf.asSlice(0, len).toArray(ValueLayout.JAVA_BYTE), StandardCharsets.UTF_8);
         }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // DocValues codec — column-reader bridge (tasks 1.1 + 1.2)
+    //
+    // These methods own the MethodHandle invocations; the MemorySegment scratch
+    // buffers are supplied by the caller (ParquetColumnReader), which owns their
+    // lifecycle via its own Arena. Read/decode methods return the raw native
+    // status code so the caller can implement the grow-and-retry protocol on
+    // RC_OVERFLOW; a {@code < 0} result is decoded into an IOException here.
+    // ────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Invokes a {@code long}-returning handle on caller-owned segments and checks the
+     * result, without allocating a per-call {@link NativeCall} arena. A {@code < 0}
+     * result is decoded into an {@link IOException}; {@code >= 0} (including
+     * {@link #RC_OVERFLOW}) is returned as-is. Used on the column-reader hot path.
+     *
+     * <p>Delegates to {@link NativeCall#invokeIOStatic} so the underlying MethodHandle
+     * invocation lives in the native-bridge library (which permits it), keeping this plugin
+     * free of the banned {@code MethodHandle#invokeWithArguments} call.
+     */
+    private static long invokeChecked(MethodHandle handle, Object... args) throws IOException {
+        return NativeCall.invokeIOStatic(handle, args);
+    }
+
+    /**
+     * Opens a per-column reader over {@code file} for {@code column}, validating that the
+     * column exists and its physical type matches {@code expectedTypeCode}
+     * (0=INT32, 1=INT64, 2=FLOAT, 3=DOUBLE, 4=BOOL, 5=BYTE_ARRAY).
+     *
+     * @return a {@code >= 0} opaque reader handle (a Rust-side i64; lives until {@link #closeColumnReader})
+     * @throws IOException if the column is missing, the type mismatches, or the file cannot be read
+     */
+    public static long openColumnReader(String file, String column, int expectedTypeCode) throws IOException {
+        try (var call = new NativeCall()) {
+            var f = call.str(file);
+            var c = call.str(column);
+            return call.invokeIO(OPEN_COLUMN_READER, f.segment(), f.len(), c.segment(), c.len(), expectedTypeCode);
+        }
+    }
+
+    /**
+     * Closes a column reader handle, releasing its native file handle and buffers.
+     * Safe to call with an already-closed/unknown handle only if the caller guards it;
+     * the native side returns an error for unknown handles.
+     *
+     * @throws IOException if the handle is unknown
+     */
+    public static void closeColumnReader(long handle) throws IOException {
+        invokeChecked(CLOSE_COLUMN_READER, handle);
+    }
+
+    /**
+     * Debug-only: returns the number of currently open native column-reader handles.
+     * Used by Property 7 (native handle non-leakage).
+     */
+    public static long openColumnReaderCount() {
+        return NativeCall.invokeStatic(OPEN_COLUMN_READER_COUNT);
+    }
+
+    /**
+     * Slow-path single-value read at {@code row} into caller-provided out-segments.
+     * The caller (ParquetColumnReader) owns the segments. Returns the native status:
+     * {@code 0} on success, {@link #RC_OVERFLOW} when {@code outBuf} was too small
+     * (required length written to {@code outLen}); throws on a native error.
+     */
+    static long readValueAtRow(
+        long handle,
+        long row,
+        MemorySegment outPresent,
+        MemorySegment outLong,
+        MemorySegment outBuf,
+        long outBufCap,
+        MemorySegment outLen
+    ) throws IOException {
+        return invokeChecked(READ_VALUE_AT_ROW, handle, row, outPresent, outLong, outBuf, outBufCap, outLen);
+    }
+
+    /**
+     * Slow-path repeated read at {@code row} into caller-provided out-segments.
+     * Returns the native status: {@code 0} on success, {@link #RC_OVERFLOW} when a
+     * buffer was too small (required element count in {@code outCount}; required byte
+     * size in {@code outByteOffsets[count]} when only the byte buffer overflowed).
+     */
+    static long readRepeatedAtRow(
+        long handle,
+        long row,
+        MemorySegment outCount,
+        MemorySegment outLongs,
+        long outLongCap,
+        MemorySegment outByteBuf,
+        MemorySegment outByteOffsets,
+        long outByteBufCap
+    ) throws IOException {
+        return invokeChecked(READ_REPEATED_AT_ROW, handle, row, outCount, outLongs, outLongCap, outByteBuf, outByteOffsets, outByteBufCap);
+    }
+
+    /** Returns the number of pages in the column (used to pre-size the page-index arrays). */
+    static long getColumnNumPages(long handle) throws IOException {
+        return invokeChecked(GET_COLUMN_NUM_PAGES, handle);
+    }
+
+    /**
+     * Loads the column's per-page jump table + stats (Layer 3/4) into caller-provided
+     * parallel out-segments, each of capacity {@code outBufCapacity} pages. Returns the
+     * native status: {@code 0} on success, {@link #RC_OVERFLOW} when capacity is too
+     * small (true page count written to {@code outActualPages}).
+     */
+    static long getColumnPageIndex(
+        long handle,
+        MemorySegment outFirstRow,
+        MemorySegment outFileOffset,
+        MemorySegment outCompressedSize,
+        MemorySegment outNullCount,
+        MemorySegment outMinLong,
+        MemorySegment outMaxLong,
+        long outBufCapacity,
+        MemorySegment outActualPages
+    ) throws IOException {
+        return invokeChecked(
+            GET_COLUMN_PAGE_INDEX,
+            handle,
+            outFirstRow,
+            outFileOffset,
+            outCompressedSize,
+            outNullCount,
+            outMinLong,
+            outMaxLong,
+            outBufCapacity,
+            outActualPages
+        );
+    }
+
+    /**
+     * Decodes the page containing {@code row} (Layer 1 values + Layer 2 presence bitset)
+     * into caller-provided out-segments. Returns the native status: {@code 0} on success,
+     * {@link #RC_OVERFLOW} when a buffer was too small (page row range and required value
+     * byte length are still written so the caller can size every buffer and retry once).
+     */
+    static long decodePageAtRow(
+        long handle,
+        long row,
+        MemorySegment outFirstRow,
+        MemorySegment outLastRow,
+        MemorySegment outValueBuf,
+        long outValueBufCap,
+        MemorySegment outValueActualLen,
+        MemorySegment outByteOffsets,
+        long outByteOffsetsCap,
+        MemorySegment outPresenceBitset,
+        long outPresenceBitsCap
+    ) throws IOException {
+        return invokeChecked(
+            DECODE_PAGE_AT_ROW,
+            handle,
+            row,
+            outFirstRow,
+            outLastRow,
+            outValueBuf,
+            outValueBufCap,
+            outValueActualLen,
+            outByteOffsets,
+            outByteOffsetsCap,
+            outPresenceBitset,
+            outPresenceBitsCap
+        );
     }
 
     private record MapArrays(NativeCall.StrArray keys, NativeCall.StrArray values) {

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/bridge/RustBridge.java
@@ -55,6 +55,7 @@ public class RustBridge {
     private static final MethodHandle OPEN_COLUMN_READER;
     private static final MethodHandle CLOSE_COLUMN_READER;
     private static final MethodHandle OPEN_COLUMN_READER_COUNT;
+    private static final MethodHandle LIQUID_CACHE_SET_ENABLED;
     private static final MethodHandle READ_VALUE_AT_ROW;
     private static final MethodHandle READ_REPEATED_AT_ROW;
     private static final MethodHandle GET_COLUMN_NUM_PAGES;
@@ -317,6 +318,10 @@ public class RustBridge {
         OPEN_COLUMN_READER_COUNT = linker.downcallHandle(
             lib.find("parquet_open_column_reader_count").orElseThrow(),
             FunctionDescriptor.of(ValueLayout.JAVA_LONG)
+        );
+        LIQUID_CACHE_SET_ENABLED = linker.downcallHandle(
+            lib.find("parquet_liquid_cache_set_enabled").orElseThrow(),
+            FunctionDescriptor.ofVoid(ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG)
         );
         READ_VALUE_AT_ROW = linker.downcallHandle(
             lib.find("parquet_read_value_at_row").orElseThrow(),
@@ -849,6 +854,17 @@ public class RustBridge {
      */
     public static long openColumnReaderCount() {
         return NativeCall.invokeStatic(OPEN_COLUMN_READER_COUNT);
+    }
+
+    /**
+     * Enables or disables the cross-query decoded-page cache (codec-owned liquid instance) and sets
+     * its memory budget in bytes. Called once at plugin init when the {@code parquet_liquid_cache}
+     * feature flag is on. When disabled (the default), {@code parquet_decode_page_at_row} never
+     * consults the cache and the decode path is unchanged. A {@code maxMemoryBytes} of 0 leaves the
+     * native default budget.
+     */
+    public static void liquidCacheSetEnabled(boolean enabled, long maxMemoryBytes) {
+        NativeCall.invokeVoid(LIQUID_CACHE_SET_ENABLED, enabled ? 1 : 0, maxMemoryBytes);
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/FieldTypeMapping.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/FieldTypeMapping.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.lucene.index.DocValuesType;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Deterministic mapping from OpenSearch field mapping types to the Lucene DocValues type and
+ * the Parquet physical type the codec reads, per the design's field-type ↔ DV-type ↔
+ * Parquet-type table.
+ *
+ * <p>Every Parquet column is written as {@code optional repeated <physical>}; whether a field
+ * is single- or multi-valued is decided by the OpenSearch mapping, not by this table. The DV
+ * type recorded here is the <em>single-valued</em> form; the matching repeated form
+ * ({@code SORTED_NUMERIC} for numerics, {@code SORTED_SET} for keyword/ip) is selected by the
+ * producer when a multi-valued iterator is requested.
+ */
+public final class FieldTypeMapping {
+
+    /** The resolved Lucene DV type + Parquet physical type for a mapping type. */
+    public record Mapping(DocValuesType singleValued, DocValuesType multiValued, ParquetPhysicalType physical) {
+    }
+
+    private static final Map<String, Mapping> BY_TYPE = Map.ofEntries(
+        Map.entry("boolean", new Mapping(DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.BOOL)),
+        Map.entry("byte", new Mapping(DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT32)),
+        Map.entry("short", new Mapping(DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT32)),
+        Map.entry("integer", new Mapping(DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT32)),
+        Map.entry("long", new Mapping(DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT64)),
+        Map.entry("float", new Mapping(DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.FLOAT)),
+        Map.entry("double", new Mapping(DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.DOUBLE)),
+        Map.entry("date", new Mapping(DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT64)),
+        Map.entry("date_nanos", new Mapping(DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT64)),
+        Map.entry("keyword", new Mapping(DocValuesType.SORTED, DocValuesType.SORTED_SET, ParquetPhysicalType.BYTE_ARRAY)),
+        Map.entry("ip", new Mapping(DocValuesType.SORTED, DocValuesType.SORTED_SET, ParquetPhysicalType.BYTE_ARRAY)),
+        Map.entry("text", new Mapping(DocValuesType.BINARY, DocValuesType.NONE, ParquetPhysicalType.BYTE_ARRAY)),
+        Map.entry("binary", new Mapping(DocValuesType.BINARY, DocValuesType.NONE, ParquetPhysicalType.BYTE_ARRAY))
+    );
+
+    private FieldTypeMapping() {}
+
+    /** True if the codec has a Parquet DocValues mapping for the given OpenSearch mapping type. */
+    public static boolean isSupported(String mappingType) {
+        return BY_TYPE.containsKey(mappingType);
+    }
+
+    /**
+     * Returns the mapping for {@code mappingType}.
+     *
+     * @throws IllegalArgumentException if the mapping type has no Parquet DocValues mapping
+     */
+    public static Mapping forType(String mappingType) {
+        Mapping m = BY_TYPE.get(mappingType);
+        if (m == null) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "Parquet DocValues codec has no mapping for OpenSearch type '%s'", mappingType)
+            );
+        }
+        return m;
+    }
+
+    /**
+     * Validates that the field's mapping type supports the requested Lucene DV type, throwing
+     * {@link IllegalArgumentException} naming the field and mapping type when incompatible.
+     *
+     * <p>The requested type may be the single- or multi-valued form of the mapping's DV type
+     * (e.g. requesting {@code SORTED_NUMERIC} for a {@code long} field, whose single-valued
+     * form is {@code NUMERIC}, is valid).
+     */
+    public static void validate(String field, String mappingType, DocValuesType requested) {
+        Mapping m = BY_TYPE.get(mappingType);
+        if (m == null) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "field '%s' has mapping type '%s', which the Parquet DocValues codec does not support",
+                    field,
+                    mappingType
+                )
+            );
+        }
+        if (requested != m.singleValued() && requested != m.multiValued()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "field '%s' (mapping type '%s') supports DocValues type %s/%s but %s was requested",
+                    field,
+                    mappingType,
+                    m.singleValued(),
+                    m.multiValued(),
+                    requested
+                )
+            );
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/OrdinalTable.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/OrdinalTable.java
@@ -1,0 +1,165 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.parquet.bridge.ParquetColumnReader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Per-segment ordinal table for {@code SortedDocValues} / {@code SortedSetDocValues} over a
+ * Parquet {@code BYTE_ARRAY} (keyword/ip) column.
+ *
+ * <p>Built lazily on first access via the naive multi-pass column scan described in the
+ * design: collect distinct terms + per-row occurrences, sort terms lex-byte ascending, assign
+ * ordinals, then materialise the per-row ordinal mapping. The single-valued layout uses
+ * {@code rowOrdinals} ({@code -1} = missing); the multi-valued layout uses CSR
+ * ({@code csrOffsets}/{@code csrOrdinals}) with each row's slice sorted ascending so
+ * {@code nextOrd()} yields ascending ordinals.
+ *
+ * <p>Lexicographic byte ordering matches Lucene's {@code BytesRef} natural order (unsigned
+ * byte comparison), so the resulting ordinals agree with Lucene's term-ordinal contract.
+ */
+public final class OrdinalTable {
+
+    /** Distinct terms in lex-byte order; {@code sortedTerms[ord]} is the term for ordinal {@code ord}. */
+    private final byte[][] sortedTerms;
+
+    /** Single-valued: ordinal per row, or {@code -1} when the row is null. */
+    private final int[] rowOrdinals;
+
+    /** Multi-valued: CSR offsets (length {@code N + 1}) into {@link #csrOrdinals}. */
+    private final int[] csrOffsets;
+
+    /** Multi-valued: flattened, per-row-ascending ordinals. */
+    private final int[] csrOrdinals;
+
+    private OrdinalTable(byte[][] sortedTerms, int[] rowOrdinals, int[] csrOffsets, int[] csrOrdinals) {
+        this.sortedTerms = sortedTerms;
+        this.rowOrdinals = rowOrdinals;
+        this.csrOffsets = csrOffsets;
+        this.csrOrdinals = csrOrdinals;
+    }
+
+    /** Number of distinct terms (ordinal count). */
+    public int valueCount() {
+        return sortedTerms.length;
+    }
+
+    /** Single-valued ordinal for {@code row}, or {@code -1} when missing. */
+    public int ordForRow(int row) {
+        return rowOrdinals[row];
+    }
+
+    /** Number of multi-valued ordinals for {@code row}. */
+    public int countForRow(int row) {
+        return csrOffsets[row + 1] - csrOffsets[row];
+    }
+
+    /** The {@code i}-th (0-based, ascending) multi-valued ordinal for {@code row}. */
+    public int ordForRow(int row, int i) {
+        return csrOrdinals[csrOffsets[row] + i];
+    }
+
+    /** Returns a fresh {@link BytesRef} over the term for {@code ord}. */
+    public BytesRef lookupOrd(int ord) {
+        return new BytesRef(sortedTerms[ord]);
+    }
+
+    /**
+     * Builds the single-valued ordinal table by scanning {@code rows} of a keyword/ip column
+     * via the reader's slow path.
+     */
+    public static OrdinalTable buildSingleValued(ParquetColumnReader reader, int numRows) throws IOException {
+        // Pass 1: collect distinct terms and per-row occurrences.
+        Map<BytesRef, List<Integer>> occurrences = new HashMap<>();
+        for (int row = 0; row < numRows; row++) {
+            byte[] v = reader.readBytesAtRow(row);
+            if (v != null) {
+                occurrences.computeIfAbsent(new BytesRef(v), k -> new ArrayList<>()).add(row);
+            }
+        }
+        Build b = assignOrdinals(occurrences);
+
+        // Pass 3: per-row single ordinal (-1 = missing).
+        int[] rowOrdinals = new int[numRows];
+        Arrays.fill(rowOrdinals, -1);
+        for (Map.Entry<BytesRef, List<Integer>> e : occurrences.entrySet()) {
+            int ord = b.termToOrd.get(e.getKey());
+            for (int r : e.getValue()) {
+                rowOrdinals[r] = ord;
+            }
+        }
+        return new OrdinalTable(b.sortedTerms, rowOrdinals, null, null);
+    }
+
+    /**
+     * Builds the multi-valued ordinal table by scanning {@code rows} of a multi-valued
+     * keyword/ip column via the reader's slow path. The per-row CSR slice is sorted ascending
+     * and de-duplicated (set semantics).
+     */
+    public static OrdinalTable buildMultiValued(ParquetColumnReader reader, int numRows) throws IOException {
+        // Pass 1: collect distinct terms and, per row, the distinct set of terms present.
+        Map<BytesRef, List<Integer>> occurrences = new HashMap<>();
+        // Track per-row term sets so we can de-duplicate within a row (SortedSet semantics).
+        List<List<BytesRef>> perRowTerms = new ArrayList<>(numRows);
+        for (int row = 0; row < numRows; row++) {
+            byte[][] vals = reader.readRepeatedBytesAtRow(row);
+            List<BytesRef> rowTerms = new ArrayList<>();
+            if (vals != null) {
+                for (byte[] v : vals) {
+                    BytesRef term = new BytesRef(v);
+                    occurrences.computeIfAbsent(term, k -> new ArrayList<>());
+                    rowTerms.add(term);
+                }
+            }
+            perRowTerms.add(rowTerms);
+        }
+        Build b = assignOrdinals(occurrences);
+
+        // Pass 3: build CSR with per-row de-duplicated, ascending ordinals.
+        int[] csrOffsets = new int[numRows + 1];
+        int[][] perRowOrds = new int[numRows][];
+        for (int row = 0; row < numRows; row++) {
+            // Distinct ordinals for this row.
+            int[] ords = perRowTerms.get(row).stream().mapToInt(t -> b.termToOrd.get(t)).distinct().sorted().toArray();
+            perRowOrds[row] = ords;
+            csrOffsets[row + 1] = csrOffsets[row] + ords.length;
+        }
+        int[] csrOrdinals = new int[csrOffsets[numRows]];
+        for (int row = 0; row < numRows; row++) {
+            System.arraycopy(perRowOrds[row], 0, csrOrdinals, csrOffsets[row], perRowOrds[row].length);
+        }
+        return new OrdinalTable(b.sortedTerms, null, csrOffsets, csrOrdinals);
+    }
+
+    /** Intermediate build state: lex-sorted distinct terms + term→ordinal map. */
+    private record Build(byte[][] sortedTerms, Map<BytesRef, Integer> termToOrd) {
+    }
+
+    private static Build assignOrdinals(Map<BytesRef, List<Integer>> occurrences) {
+        List<BytesRef> terms = new ArrayList<>(occurrences.keySet());
+        terms.sort(Comparator.naturalOrder()); // BytesRef natural order = unsigned lex-byte.
+        byte[][] sortedTerms = new byte[terms.size()][];
+        Map<BytesRef, Integer> termToOrd = new HashMap<>(terms.size() * 2);
+        for (int ord = 0; ord < terms.size(); ord++) {
+            BytesRef t = terms.get(ord);
+            sortedTerms[ord] = Arrays.copyOfRange(t.bytes, t.offset, t.offset + t.length);
+            termToOrd.put(t, ord);
+        }
+        return new Build(sortedTerms, termToOrd);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesDirectoryReader.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesDirectoryReader.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.LeafReader;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.parquet.codec.cache.QueryParquetStats;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * A {@link FilterDirectoryReader} that wraps each leaf in a {@link ParquetDocValuesLeafReader} so
+ * that Parquet-resident doc values (fields that live only in Parquet and have no Lucene segment
+ * {@link org.apache.lucene.index.FieldInfo}) are served to the standard OpenSearch search and
+ * aggregation path at read time.
+ *
+ * <p>Registered as the index reader wrapper via
+ * {@code IndexModule.setReaderWrapper(...)}; OpenSearch applies it inside
+ * {@code IndexShard#wrapSearcher}, which runs on the composite engine's
+ * {@code DataFormatAwareEngine} searcher path. Per-leaf wrapping self-gates: a leaf is only wrapped
+ * when a Parquet file resolves for its segment and the mapping declares at least one Parquet-codec
+ * field missing doc values in the Lucene segment (see {@link ParquetDocValuesLeafReader#wrapIfApplicable}).
+ */
+public final class ParquetDocValuesDirectoryReader extends FilterDirectoryReader {
+
+    private static final Logger logger = LogManager.getLogger(ParquetDocValuesDirectoryReader.class);
+
+    private final MapperService mapperService;
+    private final QueryParquetStats queryStats;
+
+    private ParquetDocValuesDirectoryReader(DirectoryReader in, MapperService mapperService, QueryParquetStats queryStats)
+        throws IOException {
+        super(in, new ParquetSubReaderWrapper(mapperService, queryStats));
+        this.mapperService = mapperService;
+        this.queryStats = queryStats;
+    }
+
+    /**
+     * Wraps {@code in} so Parquet-resident doc values become visible to Lucene query/aggregation
+     * code paths.
+     */
+    public static DirectoryReader wrap(DirectoryReader in, MapperService mapperService) throws IOException {
+        return new ParquetDocValuesDirectoryReader(in, mapperService, new QueryParquetStats());
+    }
+
+    @Override
+    protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+        // A reopened reader is a fresh search view; give it its own accumulator.
+        return new ParquetDocValuesDirectoryReader(in, mapperService, new QueryParquetStats());
+    }
+
+    @Override
+    public CacheHelper getReaderCacheHelper() {
+        // Delegate to the wrapped reader's cache helper: this reader does not change the set of
+        // live docs, so it is cache-coherent with the underlying OpenSearchDirectoryReader.
+        return in.getReaderCacheHelper();
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        // Close the wrapped leaves FIRST: that is what closes each ParquetDocValuesProducer and its
+        // ParquetColumnReaders, and the per-column stats are merged into queryStats during that close.
+        // Only then is the per-query accumulator fully populated and safe to summarize.
+        try {
+            super.doClose();
+        } finally {
+            // Benchmarking: the per-query [PARQUET_DV_QUERY_STATS] summary was demoted from info to
+            // trace so it is NOT emitted during raw-performance runs. Counters are still accumulated;
+            // enable -Dlogger trace on this class to see the summary again.
+            if (queryStats != null && queryStats.isEmpty() == false && logger.isTraceEnabled()) {
+                logger.trace("[PARQUET_DV_QUERY_STATS] {}", queryStats.summary());
+            }
+        }
+    }
+
+    /** Per-leaf wrapper that swaps in {@link ParquetDocValuesLeafReader} when applicable. */
+    private static final class ParquetSubReaderWrapper extends SubReaderWrapper {
+        private final MapperService mapperService;
+        private final QueryParquetStats queryStats;
+
+        private ParquetSubReaderWrapper(MapperService mapperService, QueryParquetStats queryStats) {
+            this.mapperService = mapperService;
+            this.queryStats = queryStats;
+        }
+
+        @Override
+        public LeafReader wrap(LeafReader reader) {
+            try {
+                return ParquetDocValuesLeafReader.wrapIfApplicable(reader, mapperService, queryStats);
+            } catch (IOException e) {
+                // SubReaderWrapper.wrap cannot throw checked exceptions; surface as unchecked so
+                // the search fails loudly rather than silently dropping Parquet doc values.
+                throw new UncheckedIOException("failed to wrap leaf reader for Parquet doc values", e);
+            }
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesFormat.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesFormat.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.lucene.codecs.DocValuesConsumer;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentWriteState;
+import org.opensearch.index.mapper.MapperService;
+
+import java.io.IOException;
+
+/**
+ * Read-only Lucene {@link DocValuesFormat} that serves doc values from Parquet for fields the
+ * composite engine has marked as Parquet-resident.
+ *
+ * <p>Registered via Lucene SPI ({@code META-INF/services/org.apache.lucene.codecs.DocValuesFormat})
+ * under the name {@value #FORMAT_NAME}. Lucene's {@code PerFieldDocValuesFormat} routes a field
+ * to this format when the segment's {@code FieldInfo} carries
+ * {@code PerFieldDocValuesFormat.format = "ParquetDocValues"} (stamped by the composite codec).
+ *
+ * <h2>Configuration</h2>
+ * Lucene SPI requires a public no-arg constructor; that instance is used only for name-based
+ * SPI discovery. The functional instance is created with a {@link MapperService} (via
+ * {@link #ParquetDocValuesFormat(MapperService)}) by the composite codec, which is needed by
+ * {@link ParquetDocValuesProducer} to resolve OpenSearch mapping types for DV-type validation.
+ * The Parquet file path is resolved per-segment by {@link ParquetSegmentLayout}.
+ */
+public final class ParquetDocValuesFormat extends DocValuesFormat {
+
+    /** SPI name of this format. */
+    public static final String FORMAT_NAME = "ParquetDocValues";
+
+    private final MapperService mapperService;
+
+    /** Required by Lucene SPI. The resulting instance is used only for name lookup. */
+    public ParquetDocValuesFormat() {
+        this(null);
+    }
+
+    /** Functional constructor used by the composite codec. */
+    public ParquetDocValuesFormat(MapperService mapperService) {
+        super(FORMAT_NAME);
+        this.mapperService = mapperService;
+    }
+
+    /** Read-only: the composite indexing engine is the sole writer of Parquet files. */
+    @Override
+    public DocValuesConsumer fieldsConsumer(SegmentWriteState state) {
+        throw new UnsupportedOperationException("ParquetDocValuesFormat is read-only; writes go through the composite indexing engine.");
+    }
+
+    @Override
+    public DocValuesProducer fieldsProducer(SegmentReadState state) throws IOException {
+        return new ParquetDocValuesProducer(state, mapperService);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesLeafReader.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesLeafReader.java
@@ -261,7 +261,11 @@ public final class ParquetDocValuesLeafReader extends FilterLeafReader {
     public NumericDocValues getNumericDocValues(String field) throws IOException {
         FieldInfo fi = parquetFieldInfo(field);
         if (fi != null && fi.getDocValuesType() == DocValuesType.NUMERIC) {
-            return RowIdRemappingDocValues.numeric(producer().getNumeric(fi), newRowIdResolver(), maxDoc());
+            RowIdResolver resolver = newRowIdResolver();
+            NumericDocValues numeric = producer().getNumeric(fi);
+            // IDENTITY (the guaranteed case — see newRowIdResolver) means docId == Parquet row, so the
+            // remap wrapper is pure indirection: return the delegate, already in docId space, directly.
+            return resolver == RowIdResolver.IDENTITY ? numeric : RowIdRemappingDocValues.numeric(numeric, resolver, maxDoc());
         }
         return in.getNumericDocValues(field);
     }
@@ -288,7 +292,10 @@ public final class ParquetDocValuesLeafReader extends FilterLeafReader {
                 ? fi
                 : newDocValuesFieldInfo(field, fi.number, DocValuesType.NUMERIC);
             NumericDocValues numeric = producer().getNumeric(asNumeric);
-            NumericDocValues remapped = RowIdRemappingDocValues.numeric(numeric, newRowIdResolver(), maxDoc());
+            RowIdResolver resolver = newRowIdResolver();
+            NumericDocValues remapped = resolver == RowIdResolver.IDENTITY
+                ? numeric
+                : RowIdRemappingDocValues.numeric(numeric, resolver, maxDoc());
             return DocValues.singleton(remapped);
         }
         return in.getSortedNumericDocValues(field);
@@ -298,7 +305,9 @@ public final class ParquetDocValuesLeafReader extends FilterLeafReader {
     public BinaryDocValues getBinaryDocValues(String field) throws IOException {
         FieldInfo fi = parquetFieldInfo(field);
         if (fi != null && fi.getDocValuesType() == DocValuesType.BINARY) {
-            return RowIdRemappingDocValues.binary(producer().getBinary(fi), newRowIdResolver(), maxDoc());
+            RowIdResolver resolver = newRowIdResolver();
+            BinaryDocValues binary = producer().getBinary(fi);
+            return resolver == RowIdResolver.IDENTITY ? binary : RowIdRemappingDocValues.binary(binary, resolver, maxDoc());
         }
         return in.getBinaryDocValues(field);
     }
@@ -307,7 +316,9 @@ public final class ParquetDocValuesLeafReader extends FilterLeafReader {
     public SortedDocValues getSortedDocValues(String field) throws IOException {
         FieldInfo fi = parquetFieldInfo(field);
         if (fi != null && fi.getDocValuesType() == DocValuesType.SORTED) {
-            return RowIdRemappingDocValues.sorted(producer().getSorted(fi), newRowIdResolver(), maxDoc());
+            RowIdResolver resolver = newRowIdResolver();
+            SortedDocValues sorted = producer().getSorted(fi);
+            return resolver == RowIdResolver.IDENTITY ? sorted : RowIdRemappingDocValues.sorted(sorted, resolver, maxDoc());
         }
         return in.getSortedDocValues(field);
     }
@@ -330,7 +341,10 @@ public final class ParquetDocValuesLeafReader extends FilterLeafReader {
                 ? fi
                 : newDocValuesFieldInfo(field, fi.number, DocValuesType.SORTED);
             SortedDocValues sorted = producer().getSorted(asSorted);
-            SortedDocValues remapped = RowIdRemappingDocValues.sorted(sorted, newRowIdResolver(), maxDoc());
+            RowIdResolver resolver = newRowIdResolver();
+            SortedDocValues remapped = resolver == RowIdResolver.IDENTITY
+                ? sorted
+                : RowIdRemappingDocValues.sorted(sorted, resolver, maxDoc());
             return DocValues.singleton(remapped);
         }
         return in.getSortedSetDocValues(field);

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesLeafReader.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesLeafReader.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SegmentReadState;
@@ -34,11 +35,14 @@ import org.opensearch.parquet.codec.cache.QueryParquetStats;
 import org.opensearch.parquet.codec.cache.RowIdStats;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A {@link FilterLeafReader} that serves doc values for Parquet-resident fields from a
@@ -103,12 +107,38 @@ public final class ParquetDocValuesLeafReader extends FilterLeafReader {
     }
 
     /**
+     * Cached result of the wrap decision for one (segment core, mapping) pair: either "don't wrap"
+     * ({@link #NO_WRAP}) or the synthesized field set + merged FieldInfos to wrap with. Segments are
+     * immutable, so for a fixed mapping the synthesis output never changes for a given core.
+     */
+    private record WrapPlan(Path parquetFile, Map<String, FieldInfo> parquetFields, FieldInfos mergedFieldInfos) {
+    }
+
+    /** Sentinel for "this segment needs no wrapping under this mapping". */
+    private static final WrapPlan NO_WRAP = new WrapPlan(null, Map.of(), null);
+
+    /**
+     * Wrap-plan cache keyed by the segment's core cache key. The plan additionally depends on the
+     * mapping, so the value stores the DocumentMapper identity it was computed against and is
+     * recomputed after a mapping update (new DocumentMapper instance). Entries are evicted by the
+     * core's close listener, mirroring how Lucene/OpenSearch key per-segment caches.
+     */
+    private static final Map<IndexReader.CacheKey, CachedWrapPlan> WRAP_PLANS = new ConcurrentHashMap<>();
+
+    private record CachedWrapPlan(Object mapperIdentity, WrapPlan plan) {
+    }
+
+    /**
      * Builds a {@link ParquetDocValuesLeafReader} for {@code in} if a Parquet file resolves for the
      * segment and the mapping declares at least one Parquet-codec-supported field that is missing
      * doc values in the Lucene segment. Otherwise returns {@code in} unwrapped.
+     *
+     * <p>The decision (Parquet file resolution + mapping walk + FieldInfo synthesis) is computed
+     * once per (segment core, mapping) and cached: segments are immutable and the mapping walk's
+     * inputs are fully determined by the segment's FieldInfos and the current DocumentMapper, so
+     * repeat searcher acquisitions reuse the plan instead of re-scanning the directory and mapping.
      */
-    public static LeafReader wrapIfApplicable(LeafReader in, MapperService mapperService, QueryParquetStats queryStats)
-        throws IOException {
+    public static LeafReader wrapIfApplicable(LeafReader in, MapperService mapperService, QueryParquetStats queryStats) throws IOException {
         SegmentReader segmentReader;
         try {
             segmentReader = Lucene.segmentReader(in);
@@ -124,9 +154,40 @@ public final class ParquetDocValuesLeafReader extends FilterLeafReader {
             IOContext.DEFAULT
         );
 
-        // Only proceed if a Parquet file exists for this segment.
-        if (ParquetSegmentLayout.resolve(state) == null) {
+        // Mapping identity: DocumentMapper is replaced wholesale on mapping update, so instance
+        // identity is a correct and cheap "mapping unchanged" signal. Null mapper (tests) -> no cache.
+        Object mapperIdentity = mapperService != null ? mapperService.documentMapper() : null;
+        IndexReader.CacheHelper coreHelper = in.getCoreCacheHelper();
+
+        WrapPlan plan;
+        if (coreHelper == null || mapperIdentity == null) {
+            plan = computeWrapPlan(in, state, mapperService);
+        } else {
+            IndexReader.CacheKey coreKey = coreHelper.getKey();
+            CachedWrapPlan cached = WRAP_PLANS.get(coreKey);
+            if (cached == null || cached.mapperIdentity() != mapperIdentity) {
+                plan = computeWrapPlan(in, state, mapperService);
+                if (WRAP_PLANS.put(coreKey, new CachedWrapPlan(mapperIdentity, plan)) == null) {
+                    // First insert for this core: evict when the segment core closes.
+                    coreHelper.addClosedListener(WRAP_PLANS::remove);
+                }
+            } else {
+                plan = cached.plan();
+            }
+        }
+
+        if (plan == NO_WRAP) {
             return in;
+        }
+        return new ParquetDocValuesLeafReader(in, mapperService, state, plan.parquetFields(), plan.mergedFieldInfos(), queryStats);
+    }
+
+    /** Uncached wrap decision: resolve the Parquet file, walk the mapping, synthesize FieldInfos. */
+    private static WrapPlan computeWrapPlan(LeafReader in, SegmentReadState state, MapperService mapperService) throws IOException {
+        // Only proceed if a Parquet file exists for this segment.
+        Path parquetFile = ParquetSegmentLayout.resolve(state);
+        if (parquetFile == null) {
+            return NO_WRAP;
         }
 
         FieldInfos existing = in.getFieldInfos();
@@ -167,11 +228,11 @@ public final class ParquetDocValuesLeafReader extends FilterLeafReader {
 
         if (parquetFields.isEmpty()) {
             // Nothing for us to serve — don't wrap.
-            return in;
+            return NO_WRAP;
         }
 
         FieldInfos mergedInfos = new FieldInfos(merged.toArray(new FieldInfo[0]));
-        return new ParquetDocValuesLeafReader(in, mapperService, state, parquetFields, mergedInfos, queryStats);
+        return new WrapPlan(parquetFile, Collections.unmodifiableMap(parquetFields), mergedInfos);
     }
 
     /** Builds a synthetic doc-values {@link FieldInfo} carrying the given DV type. */

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesLeafReader.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesLeafReader.java
@@ -1,0 +1,371 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.IOContext;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.index.engine.dataformat.DocumentInput;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.parquet.codec.cache.QueryParquetStats;
+import org.opensearch.parquet.codec.cache.RowIdStats;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link FilterLeafReader} that serves doc values for Parquet-resident fields from a
+ * {@link ParquetDocValuesProducer}, while delegating everything else to the underlying Lucene
+ * leaf reader.
+ *
+ * <p>This is the read-time integration of the Parquet DocValues codec for the case where a field
+ * is <b>Parquet-only</b> — i.e. it has no {@link FieldInfo} in the Lucene segment at all (the
+ * composite engine's Lucene secondary writes only text/keyword inverted indexes plus the row-id
+ * doc values; numeric fields like {@code age} live solely in Parquet). Lucene's
+ * {@code PerFieldDocValuesFormat} cannot route to such a field because there is no segment
+ * {@code FieldInfo} to carry the format name. This reader closes that gap by:
+ *
+ * <ol>
+ *   <li><b>Synthesizing {@link FieldInfo}s</b> — for every mapped field that the Parquet codec
+ *       supports and that is absent (or DV-less) in the delegate's {@link FieldInfos}, a synthetic
+ *       {@code FieldInfo} with the appropriate {@link DocValuesType} (from {@link FieldTypeMapping})
+ *       is added so OpenSearch's value-source layer believes the doc values exist and asks for
+ *       them.</li>
+ *   <li><b>Overriding the five DV accessors</b> — for those synthetic fields the iterators come
+ *       from a per-segment {@link ParquetDocValuesProducer}; all other fields delegate to the
+ *       underlying reader unchanged.</li>
+ * </ol>
+ *
+ * <p>One producer is built lazily per segment and closed when this reader closes. Not shared
+ * across segments.
+ */
+public final class ParquetDocValuesLeafReader extends FilterLeafReader {
+
+    private final MapperService mapperService;
+
+    /** Lazily constructed Parquet producer for this segment; null until first DV access. */
+    private ParquetDocValuesProducer producer;
+    private boolean producerInitialized;
+
+    /** Synthetic + real merged field infos, computed once. */
+    private final FieldInfos mergedFieldInfos;
+
+    /** Field name -> synthetic FieldInfo for Parquet-resident DV fields served by this reader. */
+    private final Map<String, FieldInfo> parquetFields;
+
+    /** The segment read state used to build the producer (captured at construction). */
+    private final SegmentReadState segmentReadState;
+
+    /** Per-query stats accumulator shared across all leaves of one search; may be null in tests. */
+    private final QueryParquetStats queryStats;
+
+    private ParquetDocValuesLeafReader(
+        LeafReader in,
+        MapperService mapperService,
+        SegmentReadState segmentReadState,
+        Map<String, FieldInfo> parquetFields,
+        FieldInfos mergedFieldInfos,
+        QueryParquetStats queryStats
+    ) {
+        super(in);
+        this.mapperService = mapperService;
+        this.segmentReadState = segmentReadState;
+        this.parquetFields = parquetFields;
+        this.mergedFieldInfos = mergedFieldInfos;
+        this.queryStats = queryStats;
+    }
+
+    /**
+     * Builds a {@link ParquetDocValuesLeafReader} for {@code in} if a Parquet file resolves for the
+     * segment and the mapping declares at least one Parquet-codec-supported field that is missing
+     * doc values in the Lucene segment. Otherwise returns {@code in} unwrapped.
+     */
+    public static LeafReader wrapIfApplicable(LeafReader in, MapperService mapperService, QueryParquetStats queryStats)
+        throws IOException {
+        SegmentReader segmentReader;
+        try {
+            segmentReader = Lucene.segmentReader(in);
+        } catch (RuntimeException e) {
+            // Not a segment-backed leaf (e.g. an in-memory test reader) — nothing to wrap.
+            return in;
+        }
+
+        SegmentReadState state = new SegmentReadState(
+            segmentReader.directory(),
+            segmentReader.getSegmentInfo().info,
+            segmentReader.getFieldInfos(),
+            IOContext.DEFAULT
+        );
+
+        // Only proceed if a Parquet file exists for this segment.
+        if (ParquetSegmentLayout.resolve(state) == null) {
+            return in;
+        }
+
+        FieldInfos existing = in.getFieldInfos();
+        Map<String, FieldInfo> parquetFields = new LinkedHashMap<>();
+        List<FieldInfo> merged = new ArrayList<>();
+        int maxNumber = -1;
+        for (FieldInfo fi : existing) {
+            merged.add(fi);
+            maxNumber = Math.max(maxNumber, fi.number);
+        }
+
+        // Walk the mapping. For each field the Parquet codec supports whose doc values are NOT
+        // already present in the Lucene segment, synthesize a FieldInfo with the mapped DV type.
+        for (MappedFieldType mft : mapperService.fieldTypes()) {
+            String name = mft.name();
+            if (mapperService.isMetadataField(name)) {
+                continue;
+            }
+            if (FieldTypeMapping.isSupported(mft.typeName()) == false) {
+                continue;
+            }
+            FieldInfo realFi = existing.fieldInfo(name);
+            if (realFi != null && realFi.getDocValuesType() != DocValuesType.NONE) {
+                // Lucene already serves doc values for this field — leave it to the native reader.
+                continue;
+            }
+            FieldTypeMapping.Mapping mapping = FieldTypeMapping.forType(mft.typeName());
+            DocValuesType dvType = mapping.singleValued();
+            FieldInfo synthetic = newDocValuesFieldInfo(name, ++maxNumber, dvType);
+            parquetFields.put(name, synthetic);
+            // If a DV-less FieldInfo already exists for this field, replace it with the synthetic
+            // one carrying the DV type; otherwise append.
+            if (realFi != null) {
+                merged.removeIf(fi -> fi.name.equals(name));
+            }
+            merged.add(synthetic);
+        }
+
+        if (parquetFields.isEmpty()) {
+            // Nothing for us to serve — don't wrap.
+            return in;
+        }
+
+        FieldInfos mergedInfos = new FieldInfos(merged.toArray(new FieldInfo[0]));
+        return new ParquetDocValuesLeafReader(in, mapperService, state, parquetFields, mergedInfos, queryStats);
+    }
+
+    /** Builds a synthetic doc-values {@link FieldInfo} carrying the given DV type. */
+    private static FieldInfo newDocValuesFieldInfo(String name, int number, DocValuesType dvType) {
+        return new FieldInfo(
+            name,
+            number,
+            false,                       // storeTermVector
+            true,                        // omitNorms
+            false,                       // storePayloads
+            IndexOptions.NONE,           // not indexed via this reader
+            dvType,
+            DocValuesSkipIndexType.NONE,
+            -1,                          // dvGen
+            new HashMap<>(),             // attributes (mutable, per FieldInfo contract)
+            0,                           // pointDimensionCount
+            0,                           // pointIndexDimensionCount
+            0,                           // pointNumBytes
+            0,                           // vectorDimension
+            VectorEncoding.FLOAT32,
+            VectorSimilarityFunction.EUCLIDEAN,
+            false,                       // softDeletes
+            false                        // isParentField
+        );
+    }
+
+    private synchronized ParquetDocValuesProducer producer() throws IOException {
+        if (producerInitialized == false) {
+            producer = new ParquetDocValuesProducer(segmentReadState, mapperService);
+            producer.setQueryStats(queryStats);
+            producerInitialized = true;
+        }
+        return producer;
+    }
+
+    /** Returns the synthetic FieldInfo if the given field is served from Parquet, else null. */
+    private FieldInfo parquetFieldInfo(String field) {
+        return parquetFields.get(field);
+    }
+
+    /**
+     * Builds a {@link RowIdResolver} that translates this segment's {@code docId}s to Parquet row
+     * positions by reading the underlying leaf's {@code __row_id__} doc values. Each codec iterator
+     * needs its own resolver (its own {@code __row_id__} iterator), so this is called per DV accessor.
+     * Falls back to identity when the segment has no {@code __row_id__} field.
+     */
+    private RowIdResolver newRowIdResolver() throws IOException {
+        // The write path GUARANTEES rowId == docId in every finished segment: row ids are rewritten to
+        // sequential 0..maxDoc-1 after any sort/merge (SequentialRowIdProducer) and verified by
+        // LuceneWriter.assertRowIdsSequential. So the per-doc __row_id__ lookup is pure waste here — it
+        // re-reads a value that always equals the docId. Skip it: use the no-op IDENTITY resolver.
+        //
+        // Backed by an -ea assert that mirrors the writer's invariant; if a future write path ever
+        // produced a non-identity segment, this trips in dev/test. (Costs nothing in prod.)
+        assert assertRowIdsAreIdentity() : "non-identity __row_id__ segment reached read path; IDENTITY shortcut is unsafe here";
+        if (queryStats != null) {
+            RowIdStats rowIdStats = new RowIdStats();
+            rowIdStats.markIdentity();
+            queryStats.registerRowId(rowIdStats);
+        }
+        return RowIdResolver.IDENTITY;
+    }
+
+    /** -ea-only check mirroring {@code LuceneWriter.assertRowIdsSequential}: every doc's __row_id__ == docId. */
+    private boolean assertRowIdsAreIdentity() throws IOException {
+        SortedNumericDocValues rowId = in.getSortedNumericDocValues(DocumentInput.ROW_ID_FIELD);
+        if (rowId == null) {
+            return true; // no row-id field => identity by definition
+        }
+        for (int docId = 0; docId < maxDoc(); docId++) {
+            if (rowId.advanceExact(docId) == false) {
+                return false;
+            }
+            if (rowId.nextValue() != docId) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public FieldInfos getFieldInfos() {
+        return mergedFieldInfos;
+    }
+
+    @Override
+    public NumericDocValues getNumericDocValues(String field) throws IOException {
+        FieldInfo fi = parquetFieldInfo(field);
+        if (fi != null && fi.getDocValuesType() == DocValuesType.NUMERIC) {
+            return RowIdRemappingDocValues.numeric(producer().getNumeric(fi), newRowIdResolver(), maxDoc());
+        }
+        return in.getNumericDocValues(field);
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumericDocValues(String field) throws IOException {
+        FieldInfo fi = parquetFieldInfo(field);
+        if (fi != null) {
+            // OpenSearch numeric value sources request SORTED_NUMERIC even for single-valued fields,
+            // then call DocValues.unwrapSingleton(...) to take a leaner single-valued collector when
+            // possible. We therefore serve single-valued numerics through the CACHED single-valued
+            // iterator (producer().getNumeric → ParquetNumericDocValues → PageCache hot path), apply
+            // the docId→row remapping at the numeric level, and wrap the result with
+            // DocValues.singleton(...) so the returned value is a real SingletonSortedNumericDocValues
+            // that unwrapSingleton(...) can detect. This wins on two layers: the PageCache (no per-doc
+            // FFM call) and the aggregator's single-valued fast path.
+            //
+            // TODO(multi-value): this intentionally treats every numeric field as single-valued and so
+            // breaks true multi-valued (array) numeric fields. Restore the repeated path for genuinely
+            // multi-valued columns (e.g. branch on the Parquet column's repetition level) and return
+            // RowIdRemappingDocValues.sortedNumeric(producer().getSortedNumeric(asSortedNumeric),
+            // newRowIdResolver(), maxDoc()) for those.
+            FieldInfo asNumeric = fi.getDocValuesType() == DocValuesType.NUMERIC
+                ? fi
+                : newDocValuesFieldInfo(field, fi.number, DocValuesType.NUMERIC);
+            NumericDocValues numeric = producer().getNumeric(asNumeric);
+            NumericDocValues remapped = RowIdRemappingDocValues.numeric(numeric, newRowIdResolver(), maxDoc());
+            return DocValues.singleton(remapped);
+        }
+        return in.getSortedNumericDocValues(field);
+    }
+
+    @Override
+    public BinaryDocValues getBinaryDocValues(String field) throws IOException {
+        FieldInfo fi = parquetFieldInfo(field);
+        if (fi != null && fi.getDocValuesType() == DocValuesType.BINARY) {
+            return RowIdRemappingDocValues.binary(producer().getBinary(fi), newRowIdResolver(), maxDoc());
+        }
+        return in.getBinaryDocValues(field);
+    }
+
+    @Override
+    public SortedDocValues getSortedDocValues(String field) throws IOException {
+        FieldInfo fi = parquetFieldInfo(field);
+        if (fi != null && fi.getDocValuesType() == DocValuesType.SORTED) {
+            return RowIdRemappingDocValues.sorted(producer().getSorted(fi), newRowIdResolver(), maxDoc());
+        }
+        return in.getSortedDocValues(field);
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSetDocValues(String field) throws IOException {
+        FieldInfo fi = parquetFieldInfo(field);
+        if (fi != null) {
+            // Mirror getSortedNumericDocValues: keyword value sources request SORTED_SET even for
+            // single-valued fields, then call DocValues.unwrapSingleton(...). Serve single-valued
+            // keywords through the single-valued ordinal-table iterator (producer().getSorted →
+            // ParquetSortedDocValues), remap docId→row, and wrap with DocValues.singleton(...) so the
+            // returned value is a real SingletonSortedSetDocValues that unwrapSingleton(...) detects.
+            //
+            // TODO(multi-value): intentionally treats every keyword field as single-valued and so breaks
+            // true multi-valued (array) keyword fields. Restore the multi-valued path for genuinely
+            // repeated columns and return RowIdRemappingDocValues.sortedSet(
+            // producer().getSortedSet(asSortedSet), newRowIdResolver(), maxDoc()) for those.
+            FieldInfo asSorted = fi.getDocValuesType() == DocValuesType.SORTED
+                ? fi
+                : newDocValuesFieldInfo(field, fi.number, DocValuesType.SORTED);
+            SortedDocValues sorted = producer().getSorted(asSorted);
+            SortedDocValues remapped = RowIdRemappingDocValues.sorted(sorted, newRowIdResolver(), maxDoc());
+            return DocValues.singleton(remapped);
+        }
+        return in.getSortedSetDocValues(field);
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        IOException first = null;
+        try {
+            if (producer != null) {
+                producer.close();
+            }
+        } catch (IOException e) {
+            first = e;
+        }
+        try {
+            super.doClose();
+        } catch (IOException e) {
+            if (first == null) {
+                first = e;
+            }
+        }
+        if (first != null) {
+            throw first;
+        }
+    }
+
+    // Cache helpers must delegate to the underlying reader so query/segment caches stay coherent.
+    @Override
+    public CacheHelper getCoreCacheHelper() {
+        return in.getCoreCacheHelper();
+    }
+
+    @Override
+    public CacheHelper getReaderCacheHelper() {
+        return in.getReaderCacheHelper();
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesProducer.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesProducer.java
@@ -106,23 +106,35 @@ public final class ParquetDocValuesProducer extends DocValuesProducer {
         }
         this.parquetFile = resolved;
 
-        ParquetFileMetadata metadata = RustBridge.getFileMetadata(parquetFile.toString());
-        this.parquetRowCount = metadata.numRows();
-        if (parquetRowCount != maxDoc) {
-            throw new IllegalStateException(
-                String.format(
-                    Locale.ROOT,
-                    "Parquet/Lucene row-count mismatch for segment '%s': Lucene maxDoc=%d but Parquet numRows=%d (file=%s). "
-                        + "The resolved Parquet file must contain exactly the segment's rows; docId→row translation is handled "
-                        + "separately via __row_id__.",
-                    state.segmentInfo.name,
-                    maxDoc,
-                    parquetRowCount,
-                    parquetFile
-                )
-            );
-        }
+        // The write path GUARANTEES the resolved Parquet file contains exactly the segment's rows
+        // (one row per doc, in doc order — the same invariant chain that makes rowId == docId).
+        // Re-reading the Parquet footer here just to re-verify numRows costs one FFM metadata
+        // crossing per segment per producer for a value that never disagrees. Trust it:
+        // parquetRowCount == maxDoc by construction, backed by an -ea-only assert that still does
+        // the footer read in dev/test and trips if a future write path breaks the invariant.
+        assert assertParquetRowCountMatches(state.segmentInfo.name) : "Parquet numRows != maxDoc for segment "
+            + state.segmentInfo.name
+            + " (file="
+            + parquetFile
+            + "); writer invariant violated — the trusted row-count shortcut is unsafe";
+        this.parquetRowCount = maxDoc;
         this.setupNanos = System.nanoTime() - setupStart;
+    }
+
+    /** -ea-only check mirroring the writer invariant: the Parquet file's numRows equals the segment's maxDoc. */
+    private boolean assertParquetRowCountMatches(String segmentName) throws IOException {
+        ParquetFileMetadata metadata = RustBridge.getFileMetadata(parquetFile.toString());
+        if (metadata.numRows() != maxDoc) {
+            logger.error(
+                "Parquet/Lucene row-count mismatch for segment '{}': Lucene maxDoc={} but Parquet numRows={} (file={})",
+                segmentName,
+                maxDoc,
+                metadata.numRows(),
+                parquetFile
+            );
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesProducer.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetDocValuesProducer.java
@@ -1,0 +1,318 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.codecs.DocValuesProducer;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.opensearch.index.mapper.MappedFieldType;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.parquet.bridge.ParquetColumnReader;
+import org.opensearch.parquet.bridge.ParquetFileMetadata;
+import org.opensearch.parquet.bridge.RustBridge;
+import org.opensearch.parquet.codec.cache.BufferPool;
+import org.opensearch.parquet.codec.cache.QueryParquetStats;
+import org.opensearch.parquet.codec.iter.ParquetBinaryDocValues;
+import org.opensearch.parquet.codec.iter.ParquetNumericDocValues;
+import org.opensearch.parquet.codec.iter.ParquetSortedDocValues;
+import org.opensearch.parquet.codec.iter.ParquetSortedNumericDocValues;
+import org.opensearch.parquet.codec.iter.ParquetSortedSetDocValues;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Read-only {@link DocValuesProducer} that materializes per-document values from a Parquet
+ * file through Lucene's DocValues iterator API, for <b>flat indices only</b>.
+ *
+ * <h2>Row ID = Doc ID invariant (precondition)</h2>
+ * This producer relies on the composite indexing engine's guarantee that Lucene document
+ * {@code N} corresponds to Parquet row position {@code N} within the same segment's Parquet
+ * file, with one Lucene document per Parquet row and no translation table. The invariant is
+ * verified at construction by asserting the Parquet file's {@code numRows} equals the segment's
+ * {@code maxDoc}; a mismatch throws {@link IllegalStateException}. Nested documents are out of
+ * scope.
+ *
+ * <h2>Laziness and lifecycle</h2>
+ * The constructor resolves the Parquet file and checks the invariant but opens no native
+ * column-reader handle. Each {@code getX(field)} lazily opens (and caches) a
+ * {@link ParquetColumnReader}; {@code getSorted}/{@code getSortedSet} additionally build (and
+ * cache) an {@link OrdinalTable} on first access. {@link #close()} releases every reader,
+ * ordinal table, and the shared {@link BufferPool}, and is idempotent.
+ *
+ * <p>Not thread-safe: one producer serves one segment on one query thread.
+ */
+public final class ParquetDocValuesProducer extends DocValuesProducer {
+
+    private static final Logger logger = LogManager.getLogger(ParquetDocValuesProducer.class);
+
+    private final Path parquetFile;
+    private final MapperService mapperService;
+    private final int maxDoc;
+    private final long parquetRowCount;
+
+    private final BufferPool bufferPool = new BufferPool();
+    private final Map<String, ParquetColumnReader> columnReaders = new HashMap<>();
+    private final Map<String, OrdinalTable> ordinalTables = new HashMap<>();
+
+    /** Nanoseconds spent in producer setup (file resolve + metadata read); flushed when query stats are attached. */
+    private final long setupNanos;
+    /** Optional per-query accumulator; propagated to each column reader so its stats roll up at close. */
+    private QueryParquetStats queryStats;
+
+    private boolean closed;
+
+    /**
+     * Constructs the producer for {@code state}'s segment.
+     *
+     * @param mapperService resolves OpenSearch mapping types for DV-type validation (may be
+     *                      {@code null} only in low-level tests that bypass type validation)
+     * @throws IOException if the Parquet file for the segment cannot be resolved (Req 9.3)
+     * @throws IllegalStateException if the Row ID = Doc ID invariant is violated (Req 12.3)
+     */
+    public ParquetDocValuesProducer(SegmentReadState state, MapperService mapperService) throws IOException {
+        long setupStart = System.nanoTime();
+        this.mapperService = mapperService;
+        this.maxDoc = state.segmentInfo.maxDoc();
+
+        Path resolved = ParquetSegmentLayout.resolve(state);
+        if (resolved == null) {
+            throw new IOException(
+                String.format(
+                    Locale.ROOT,
+                    "no Parquet file found for segment '%s' (maxDoc=%d); cannot serve Parquet doc values",
+                    state.segmentInfo.name,
+                    maxDoc
+                )
+            );
+        }
+        this.parquetFile = resolved;
+
+        ParquetFileMetadata metadata = RustBridge.getFileMetadata(parquetFile.toString());
+        this.parquetRowCount = metadata.numRows();
+        if (parquetRowCount != maxDoc) {
+            throw new IllegalStateException(
+                String.format(
+                    Locale.ROOT,
+                    "Parquet/Lucene row-count mismatch for segment '%s': Lucene maxDoc=%d but Parquet numRows=%d (file=%s). "
+                        + "The resolved Parquet file must contain exactly the segment's rows; docId→row translation is handled "
+                        + "separately via __row_id__.",
+                    state.segmentInfo.name,
+                    maxDoc,
+                    parquetRowCount,
+                    parquetFile
+                )
+            );
+        }
+        this.setupNanos = System.nanoTime() - setupStart;
+    }
+
+    /**
+     * Attaches the per-query accumulator. The producer's setup time is folded in immediately, and
+     * the accumulator is propagated to every column reader (existing and future) so each reader's
+     * stats roll up into the query total when it closes.
+     */
+    public void setQueryStats(QueryParquetStats queryStats) {
+        this.queryStats = queryStats;
+        if (queryStats != null) {
+            queryStats.addProducerSetupNanos(setupNanos);
+            for (ParquetColumnReader reader : columnReaders.values()) {
+                reader.setQueryStats(queryStats);
+            }
+        }
+    }
+
+    // ── DocValuesProducer API ──
+
+    @Override
+    public NumericDocValues getNumeric(FieldInfo field) throws IOException {
+        ensureOpen();
+        validate(field, DocValuesType.NUMERIC);
+        ParquetColumnReader reader = readerFor(field, false);
+        return new ParquetNumericDocValues(reader, maxDoc);
+    }
+
+    @Override
+    public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
+        ensureOpen();
+        validate(field, DocValuesType.SORTED_NUMERIC);
+        ParquetColumnReader reader = readerFor(field, true);
+        return new ParquetSortedNumericDocValues(reader, maxDoc);
+    }
+
+    @Override
+    public BinaryDocValues getBinary(FieldInfo field) throws IOException {
+        ensureOpen();
+        validate(field, DocValuesType.BINARY);
+        ParquetColumnReader reader = readerFor(field, false);
+        return new ParquetBinaryDocValues(reader, maxDoc);
+    }
+
+    @Override
+    public SortedDocValues getSorted(FieldInfo field) throws IOException {
+        ensureOpen();
+        validate(field, DocValuesType.SORTED);
+        OrdinalTable table = ordinalTableFor(field, false);
+        return new ParquetSortedDocValues(table, maxDoc);
+    }
+
+    @Override
+    public SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
+        ensureOpen();
+        validate(field, DocValuesType.SORTED_SET);
+        OrdinalTable table = ordinalTableFor(field, true);
+        return new ParquetSortedSetDocValues(table, maxDoc);
+    }
+
+    /** No skip lists for Parquet-backed doc values. */
+    @Override
+    public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+        return null;
+    }
+
+    /**
+     * Verifies the underlying Parquet file is accessible and its metadata is consistent: the
+     * file opens, {@code numRows} matches the value cached at construction, and the metadata
+     * round-trip (which includes the writer-side CRC) succeeds.
+     */
+    @Override
+    public void checkIntegrity() throws IOException {
+        ParquetFileMetadata metadata = RustBridge.getFileMetadata(parquetFile.toString());
+        if (metadata.numRows() != parquetRowCount) {
+            throw new IOException(
+                String.format(
+                    Locale.ROOT,
+                    "checkIntegrity: Parquet numRows changed for %s: expected %d, found %d",
+                    parquetFile,
+                    parquetRowCount,
+                    metadata.numRows()
+                )
+            );
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        // Aggregate cache-effectiveness summary across all columns touched by this segment's
+        // producer. Per-column detail is logged by each ParquetColumnReader on its own close.
+        if (columnReaders.isEmpty() == false && logger.isDebugEnabled()) {
+            long hits = 0, misses = 0, decodes = 0, allNullSkips = 0;
+            for (ParquetColumnReader reader : columnReaders.values()) {
+                hits += reader.stats().pageCacheHits();
+                misses += reader.stats().pageCacheMisses();
+                decodes += reader.stats().pageDecodes();
+                allNullSkips += reader.stats().allNullPageSkips();
+            }
+            long lookups = hits + misses;
+            double hitRate = lookups == 0 ? 0.0 : (double) hits / lookups * 100.0;
+            logger.debug(
+                "[PARQUET_DV_CACHE_STATS] segment summary: file={} columns={} | L1/2 hits={} misses={} (hitRate={}%) "
+                    + "| L4 allNullSkips={} | FFM pageDecodes={}",
+                parquetFile,
+                columnReaders.size(),
+                hits,
+                misses,
+                String.format(Locale.ROOT, "%.2f", hitRate),
+                allNullSkips,
+                decodes
+            );
+        }
+        closed = true;
+        IOException first = null;
+        for (ParquetColumnReader reader : columnReaders.values()) {
+            try {
+                reader.close();
+            } catch (IOException | RuntimeException e) {
+                if (first == null && e instanceof IOException io) {
+                    first = io;
+                }
+                // Suppress per-reader errors so every reader gets a chance to close.
+            }
+        }
+        columnReaders.clear();
+        ordinalTables.clear();
+        bufferPool.close();
+        if (first != null) {
+            throw first;
+        }
+    }
+
+    // ── internals ──
+
+    /** Validates the field's mapping type supports the requested DV type, when a mapper is present. */
+    private void validate(FieldInfo field, DocValuesType requested) {
+        if (mapperService == null) {
+            return; // low-level tests may bypass mapping validation
+        }
+        FieldTypeMapping.validate(field.getName(), mappingType(field), requested);
+    }
+
+    private String mappingType(FieldInfo field) {
+        MappedFieldType mft = mapperService.fieldType(field.getName());
+        if (mft == null) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "field '%s' has no mapping; cannot resolve Parquet column type", field.getName())
+            );
+        }
+        return mft.typeName();
+    }
+
+    /** Resolves the Parquet physical type for a field from its mapping (or infers for tests). */
+    private ParquetPhysicalType physicalType(FieldInfo field) {
+        if (mapperService != null) {
+            return FieldTypeMapping.forType(mappingType(field)).physical();
+        }
+        // Without a mapper, infer from the Lucene DV type recorded on the field.
+        return switch (field.getDocValuesType()) {
+            case BINARY, SORTED, SORTED_SET -> ParquetPhysicalType.BYTE_ARRAY;
+            default -> ParquetPhysicalType.INT64;
+        };
+    }
+
+    private ParquetColumnReader readerFor(FieldInfo field, boolean repeated) throws IOException {
+        ParquetColumnReader reader = columnReaders.get(field.getName());
+        if (reader == null) {
+            reader = ParquetColumnReader.open(parquetFile, field.getName(), physicalType(field), repeated, bufferPool);
+            reader.setQueryStats(queryStats);
+            columnReaders.put(field.getName(), reader);
+        }
+        return reader;
+    }
+
+    private OrdinalTable ordinalTableFor(FieldInfo field, boolean multiValued) throws IOException {
+        OrdinalTable table = ordinalTables.get(field.getName());
+        if (table == null) {
+            ParquetColumnReader reader = readerFor(field, multiValued);
+            table = multiValued ? OrdinalTable.buildMultiValued(reader, maxDoc) : OrdinalTable.buildSingleValued(reader, maxDoc);
+            ordinalTables.put(field.getName(), table);
+        }
+        return table;
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("ParquetDocValuesProducer is closed");
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetPhysicalType.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetPhysicalType.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+/**
+ * The Parquet physical type of a column, as understood by the native column reader.
+ *
+ * <p>The {@link #code()} values are the discriminants exchanged with the Rust FFM
+ * bridge ({@code parquet_open_column_reader}'s {@code expected_type} argument and the
+ * physical-type validation it performs). They must stay in lock-step with the
+ * {@code TYPE_*} constants in {@code ffm.rs}.
+ *
+ * <p>Parquet's {@code FIXED_LEN_BYTE_ARRAY} is folded into {@link #BYTE_ARRAY} because
+ * the codec treats both as opaque byte sequences for {@code BinaryDocValues} purposes.
+ */
+public enum ParquetPhysicalType {
+    /** 32-bit signed integer; raw bits sign-extended to a {@code long}. */
+    INT32(0),
+    /** 64-bit signed integer; raw bits verbatim. */
+    INT64(1),
+    /** 32-bit IEEE-754 float; raw bits via {@link Float#floatToRawIntBits}. */
+    FLOAT(2),
+    /** 64-bit IEEE-754 double; raw bits via {@link Double#doubleToRawLongBits}. */
+    DOUBLE(3),
+    /** Boolean; encoded as 0 or 1. */
+    BOOL(4),
+    /** Variable- or fixed-length byte array (UTF-8 strings, IP, binary). */
+    BYTE_ARRAY(5);
+
+    private final int code;
+
+    ParquetPhysicalType(int code) {
+        this.code = code;
+    }
+
+    /** The native discriminant exchanged with the Rust FFM bridge. */
+    public int code() {
+        return code;
+    }
+
+    /** True for the fixed-width primitive types whose values are exchanged as raw {@code long} bits. */
+    public boolean isPrimitive() {
+        return this != BYTE_ARRAY;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetSegmentLayout.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/ParquetSegmentLayout.java
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FilterDirectory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resolves the Parquet file that backs a Lucene segment's Parquet-resident doc values.
+ *
+ * <p>The composite indexing engine writes Parquet files into a {@code parquet/} data
+ * directory using the deterministic name {@code _parquet_file_generation_<hexGeneration>.parquet}
+ * (see {@code ParquetIndexingEngine.buildParquetFileName}). A Lucene segment is bound to its
+ * Parquet file through one of two mechanisms, tried in order:
+ *
+ * <ol>
+ *   <li><b>Segment attribute</b> — the composite codec (segment-level {@code DocValuesFormat})
+ *       stamps {@link #PARQUET_FILE_ATTRIBUTE} on the {@code SegmentInfo} with the resolved
+ *       file path. This is the authoritative binding once composite routing (task 10) is wired.</li>
+ *   <li><b>Directory scan</b> — when no attribute is present (e.g. read-time reader wrapping
+ *       against an already-written index, or unit tests that write a single Parquet file
+ *       alongside the segment), the segment directory, a {@code parquet/} subdirectory, and a
+ *       sibling {@code parquet/} directory (the composite-engine deployment layout) are scanned
+ *       for a {@code *.parquet} file. The scan only resolves when a candidate directory holds
+ *       exactly one Parquet file; if it holds more than one the binding is ambiguous and an
+ *       {@link IOException} is thrown rather than guessing (the {@link #PARQUET_FILE_ATTRIBUTE}
+ *       must be supplied in that case).</li>
+ * </ol>
+ *
+ * <p>Returns {@code null} when no Parquet file can be resolved; the producer turns that into a
+ * descriptive {@link IOException} (Req 9.3).
+ */
+public final class ParquetSegmentLayout {
+
+    /** {@code SegmentInfo} attribute key holding the absolute Parquet file path for the segment. */
+    public static final String PARQUET_FILE_ATTRIBUTE = "parquet.docvalues.file";
+
+    /** Parquet file extension, matching the indexing engine. */
+    static final String PARQUET_EXT = ".parquet";
+
+    private ParquetSegmentLayout() {}
+
+    /**
+     * Resolves the Parquet file path for {@code state}'s segment, or {@code null} if none exists.
+     *
+     * @throws IOException if directory access fails
+     */
+    public static Path resolve(SegmentReadState state) throws IOException {
+        // 1. Authoritative: explicit path stamped on the segment by the composite codec.
+        String attr = state.segmentInfo.getAttribute(PARQUET_FILE_ATTRIBUTE);
+        if (attr != null && attr.isEmpty() == false) {
+            Path p = Path.of(attr);
+            return Files.exists(p) ? p : null;
+        }
+
+        // 2. Fallback: scan for a .parquet file across the locations the composite/parquet engines
+        //    use. The composite engine's ParquetIndexingEngine writes files to the shard's
+        //    "parquet/" data directory, which is a *sibling* of the Lucene segment directory
+        //    (shardPath/parquet vs shardPath/index), so we must look both inside the segment
+        //    directory (single-file unit-test layout) and in the sibling parquet/ dir
+        //    (real deployment layout).
+        Path dir = directoryPath(state.directory);
+        if (dir == null) {
+            return null;
+        }
+        String segmentName = state.segmentInfo.name;
+        for (Path candidate : candidateParquetDirs(dir)) {
+            Path found = singleParquetFile(candidate, segmentName);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Candidate directories to scan for the segment's Parquet file, in priority order:
+     * <ol>
+     *   <li>the Lucene segment directory itself (unit tests that drop a single {@code .parquet}
+     *       alongside the segment);</li>
+     *   <li>a {@code parquet/} subdirectory of the segment directory;</li>
+     *   <li>a {@code parquet/} directory that is a sibling of the segment directory — the real
+     *       composite-engine layout, where the Lucene index lives in {@code shardPath/index} and
+     *       Parquet files in {@code shardPath/parquet}.</li>
+     * </ol>
+     */
+    private static List<Path> candidateParquetDirs(Path luceneDir) {
+        List<Path> dirs = new ArrayList<>(3);
+        dirs.add(luceneDir);
+        dirs.add(luceneDir.resolve("parquet"));
+        Path parent = luceneDir.getParent();
+        if (parent != null) {
+            dirs.add(parent.resolve("parquet"));
+        }
+        return dirs;
+    }
+
+    /**
+     * Returns the single {@code *.parquet} file in {@code dir}, or {@code null} when the directory
+     * has none. When the directory contains <b>more than one</b> Parquet file the segment-to-file
+     * binding is ambiguous (e.g. an un-stamped merged segment whose data directory holds several
+     * per-generation files); guessing lexicographically risks reading the wrong file and returning
+     * silently incorrect values, so this fails loudly with an {@link IOException} instead. The
+     * authoritative path (the {@link #PARQUET_FILE_ATTRIBUTE} stamped by the engine) must be used in
+     * that case.
+     *
+     * @param segmentName the Lucene segment name, included in the error for diagnosability
+     */
+    private static Path singleParquetFile(Path dir, String segmentName) throws IOException {
+        if (Files.isDirectory(dir) == false) {
+            return null;
+        }
+        List<Path> matches = new ArrayList<>();
+        try (var stream = Files.newDirectoryStream(dir, "*" + PARQUET_EXT)) {
+            for (Path p : stream) {
+                matches.add(p);
+            }
+        }
+        if (matches.isEmpty()) {
+            return null;
+        }
+        if (matches.size() > 1) {
+            matches.sort(Path::compareTo);
+            throw new IOException(
+                "Ambiguous Parquet doc-values file for segment '"
+                    + segmentName
+                    + "': directory ["
+                    + dir
+                    + "] contains "
+                    + matches.size()
+                    + " .parquet files "
+                    + matches
+                    + "; cannot safely resolve by directory scan. The backing file must be supplied via the '"
+                    + PARQUET_FILE_ATTRIBUTE
+                    + "' segment attribute (e.g. a merged segment whose file was not stamped)."
+            );
+        }
+        return matches.get(0);
+    }
+
+    /**
+     * Extracts the filesystem path backing a Lucene {@link Directory}, unwrapping
+     * {@link FilterDirectory} layers. Returns {@code null} for non-filesystem directories
+     * (e.g. in-memory test directories), in which case attribute-based resolution is required.
+     */
+    private static Path directoryPath(Directory directory) {
+        Directory unwrapped = FilterDirectory.unwrap(directory);
+        if (unwrapped instanceof FSDirectory fs) {
+            return fs.getDirectory();
+        }
+        return null;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/RowIdRemappingDocValues.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/RowIdRemappingDocValues.java
@@ -1,0 +1,355 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.parquet.codec.cache.RowIdStats;
+
+import java.io.IOException;
+
+/**
+ * Decorators that adapt the Parquet DocValues iterators (which address values by Parquet
+ * <b>row position</b>) to Lucene's {@code docId}-space contract, translating each {@code docId} to
+ * its Parquet row via a {@link RowIdResolver} before delegating.
+ *
+ * <p>The wrapped (delegate) iterator produced by {@link ParquetDocValuesProducer} treats the integer
+ * passed to {@code advanceExact} as the Parquet row position. These decorators therefore:
+ * <ul>
+ *   <li>accept {@code advanceExact(docId)} in Lucene doc-id space,</li>
+ *   <li>resolve {@code row = resolver.toRowId(docId)},</li>
+ *   <li>delegate {@code advanceExact((int) row)} to read the value at that Parquet row, and</li>
+ *   <li>expose {@code docID()} / {@code nextDoc()} / {@code advance()} in doc-id space.</li>
+ * </ul>
+ *
+ * <p>When the resolver is {@link RowIdResolver#IDENTITY} the translation is a no-op and behavior is
+ * identical to using the delegate directly (the un-merged, single-generation case).
+ *
+ * <p>Value accessors ({@code longValue}, {@code binaryValue}, ordinal lookups, etc.) delegate
+ * straight through, since after {@code advanceExact} the delegate is positioned on the correct row.
+ */
+final class RowIdRemappingDocValues {
+
+    private RowIdRemappingDocValues() {}
+
+    static NumericDocValues numeric(NumericDocValues delegate, RowIdResolver resolver, int maxDoc) {
+        return new NumericDocValues() {
+            private int doc = -1;
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                doc = target;
+                return delegate.advanceExact((int) resolver.toRowId(target));
+            }
+
+            @Override
+            public long longValue() throws IOException {
+                return delegate.longValue();
+            }
+
+            @Override
+            public int docID() {
+                return doc;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                return advance(doc + 1);
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                for (int d = target; d < maxDoc; d++) {
+                    if (advanceExact(d)) {
+                        return d;
+                    }
+                }
+                doc = NO_MORE_DOCS;
+                return NO_MORE_DOCS;
+            }
+
+            @Override
+            public long cost() {
+                return delegate.cost();
+            }
+        };
+    }
+
+    static SortedNumericDocValues sortedNumeric(SortedNumericDocValues delegate, RowIdResolver resolver, int maxDoc) {
+        return new SortedNumericDocValues() {
+            private int doc = -1;
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                doc = target;
+                return delegate.advanceExact((int) resolver.toRowId(target));
+            }
+
+            @Override
+            public long nextValue() throws IOException {
+                return delegate.nextValue();
+            }
+
+            @Override
+            public int docValueCount() {
+                return delegate.docValueCount();
+            }
+
+            @Override
+            public int docID() {
+                return doc;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                return advance(doc + 1);
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                for (int d = target; d < maxDoc; d++) {
+                    if (advanceExact(d)) {
+                        return d;
+                    }
+                }
+                doc = NO_MORE_DOCS;
+                return NO_MORE_DOCS;
+            }
+
+            @Override
+            public long cost() {
+                return delegate.cost();
+            }
+        };
+    }
+
+    static BinaryDocValues binary(BinaryDocValues delegate, RowIdResolver resolver, int maxDoc) {
+        return new BinaryDocValues() {
+            private int doc = -1;
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                doc = target;
+                return delegate.advanceExact((int) resolver.toRowId(target));
+            }
+
+            @Override
+            public BytesRef binaryValue() throws IOException {
+                return delegate.binaryValue();
+            }
+
+            @Override
+            public int docID() {
+                return doc;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                return advance(doc + 1);
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                for (int d = target; d < maxDoc; d++) {
+                    if (advanceExact(d)) {
+                        return d;
+                    }
+                }
+                doc = NO_MORE_DOCS;
+                return NO_MORE_DOCS;
+            }
+
+            @Override
+            public long cost() {
+                return delegate.cost();
+            }
+        };
+    }
+
+    static SortedDocValues sorted(SortedDocValues delegate, RowIdResolver resolver, int maxDoc) {
+        return new SortedDocValues() {
+            private int doc = -1;
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                doc = target;
+                return delegate.advanceExact((int) resolver.toRowId(target));
+            }
+
+            @Override
+            public int ordValue() throws IOException {
+                return delegate.ordValue();
+            }
+
+            @Override
+            public BytesRef lookupOrd(int ord) throws IOException {
+                return delegate.lookupOrd(ord);
+            }
+
+            @Override
+            public int getValueCount() {
+                return delegate.getValueCount();
+            }
+
+            @Override
+            public int docID() {
+                return doc;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                return advance(doc + 1);
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                for (int d = target; d < maxDoc; d++) {
+                    if (advanceExact(d)) {
+                        return d;
+                    }
+                }
+                doc = NO_MORE_DOCS;
+                return NO_MORE_DOCS;
+            }
+
+            @Override
+            public long cost() {
+                return delegate.cost();
+            }
+
+            @Override
+            public TermsEnum termsEnum() throws IOException {
+                return delegate.termsEnum();
+            }
+        };
+    }
+
+    static SortedSetDocValues sortedSet(SortedSetDocValues delegate, RowIdResolver resolver, int maxDoc) {
+        return new SortedSetDocValues() {
+            private int doc = -1;
+
+            @Override
+            public boolean advanceExact(int target) throws IOException {
+                doc = target;
+                return delegate.advanceExact((int) resolver.toRowId(target));
+            }
+
+            @Override
+            public long nextOrd() throws IOException {
+                return delegate.nextOrd();
+            }
+
+            @Override
+            public int docValueCount() {
+                return delegate.docValueCount();
+            }
+
+            @Override
+            public BytesRef lookupOrd(long ord) throws IOException {
+                return delegate.lookupOrd(ord);
+            }
+
+            @Override
+            public long getValueCount() {
+                return delegate.getValueCount();
+            }
+
+            @Override
+            public int docID() {
+                return doc;
+            }
+
+            @Override
+            public int nextDoc() throws IOException {
+                return advance(doc + 1);
+            }
+
+            @Override
+            public int advance(int target) throws IOException {
+                for (int d = target; d < maxDoc; d++) {
+                    if (advanceExact(d)) {
+                        return d;
+                    }
+                }
+                doc = NO_MORE_DOCS;
+                return NO_MORE_DOCS;
+            }
+
+            @Override
+            public long cost() {
+                return delegate.cost();
+            }
+
+            @Override
+            public TermsEnum termsEnum() throws IOException {
+                return delegate.termsEnum();
+            }
+        };
+    }
+
+    /**
+     * Builds a {@link RowIdResolver} from a {@code __row_id__} {@link SortedNumericDocValues} iterator
+     * over the same segment ({@code __row_id__} is written as a single-valued
+     * {@code SortedNumericDocValuesField}). The returned resolver reads the row-id value for each
+     * {@code docId}; it is forward-only (callers must pass non-decreasing doc ids), matching the codec
+     * iterators' access pattern. If {@code rowIdDocValues} is {@code null} (no row-id field in the
+     * segment) this returns {@link RowIdResolver#IDENTITY}.
+     *
+     * <p>Each codec DocValues iterator advances independently, so callers must build a <b>separate</b>
+     * resolver (backed by its own {@code __row_id__} iterator) per codec iterator.
+     */
+    static RowIdResolver resolverFrom(SortedNumericDocValues rowIdDocValues) {
+        return resolverFrom(rowIdDocValues, null);
+    }
+
+    /**
+     * As {@link #resolverFrom(SortedNumericDocValues)}, but records the lookup <b>count</b> into
+     * {@code stats} (and marks IDENTITY when there is no row-id field). When {@code stats} is null,
+     * no instrumentation is added (the resolver is the plain hot path).
+     *
+     * <p>Only the lookup count is recorded — never per-call timing. The per-document work is on the
+     * order of tens of nanoseconds, comparable to {@code System.nanoTime()} itself, so timing each
+     * call cannot produce a trustworthy figure; the actual wall-clock spent here is measured with a
+     * CPU flamegraph instead (see {@link RowIdStats}).
+     */
+    static RowIdResolver resolverFrom(SortedNumericDocValues rowIdDocValues, RowIdStats stats) {
+        if (rowIdDocValues == null) {
+            if (stats != null) {
+                stats.markIdentity();
+            }
+            return RowIdResolver.IDENTITY;
+        }
+        if (stats == null) {
+            return docId -> {
+                if (rowIdDocValues.advanceExact(docId) == false) {
+                    throw new IllegalStateException(
+                        "missing __row_id__ doc value for docId=" + docId + "; cannot translate to Parquet row position"
+                    );
+                }
+                return rowIdDocValues.nextValue();
+            };
+        }
+        return docId -> {
+            if (rowIdDocValues.advanceExact(docId) == false) {
+                throw new IllegalStateException(
+                    "missing __row_id__ doc value for docId=" + docId + "; cannot translate to Parquet row position"
+                );
+            }
+            // __row_id__ is single-valued; take the first (and only) value.
+            long rowId = rowIdDocValues.nextValue();
+            stats.recordLookup();
+            return rowId;
+        };
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/RowIdResolver.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/RowIdResolver.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import java.io.IOException;
+
+/**
+ * Translates a Lucene {@code docId} (within a single segment) into the Parquet <b>row position</b>
+ * for that document in the segment's Parquet file.
+ *
+ * <p>The Parquet DocValues iterators address rows positionally. In the simplest case — a
+ * freshly-refreshed, un-merged segment — Lucene {@code docId} equals the Parquet row, so the
+ * {@link #IDENTITY} resolver is correct. After a merge, the composite engine reorders documents and
+ * rewrites the per-document {@code __row_id__} doc value so that {@code docId} no longer equals the
+ * Parquet row; the correct row must then be read from {@code __row_id__}. A resolver backed by that
+ * doc value (see the leaf reader) provides the general, merge-safe translation.
+ *
+ * <p>Resolvers are <b>forward-only and stateful</b> when backed by a doc-values iterator: callers
+ * must invoke {@link #toRowId(int)} with non-decreasing {@code docId}s, matching the ascending
+ * access pattern of the codec's DocValues iterators. One resolver instance is therefore bound to one
+ * codec iterator instance.
+ */
+@FunctionalInterface
+public interface RowIdResolver {
+
+    /**
+     * Returns the Parquet row position for {@code docId}.
+     *
+     * @param docId the Lucene document id within the segment
+     * @return the Parquet row position to read for this document
+     * @throws IOException if the underlying row-id doc values cannot be read
+     * @throws IllegalStateException if the document has no row-id value (a correctness invariant
+     *         violation — every composite-engine document carries {@code __row_id__})
+     */
+    long toRowId(int docId) throws IOException;
+
+    /** Identity mapping: {@code rowId == docId}. Correct for un-merged, single-generation segments. */
+    RowIdResolver IDENTITY = docId -> docId;
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/BufferPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/BufferPool.java
@@ -47,7 +47,11 @@ public final class BufferPool implements AutoCloseable {
         long capacity;
     }
 
-    private final Arena arena = Arena.ofConfined();
+    // Shared arena allows a prefetch thread to allocate/write segments while the query thread
+    // reads from a previously decoded page. Access checks are slightly costlier than confined
+    // but enable decode overlap. close() is deterministic: callers must join any in-flight
+    // prefetch before calling close (shared-arena close throws if any segment is mid-access).
+    private final Arena arena = Arena.ofShared();
     private final Map<String, Slot> slots = new HashMap<>();
     private boolean closed;
 

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/BufferPool.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/BufferPool.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 5 — hot-buffer pooling. Owns a confined {@link Arena} and hands out reusable,
+ * grow-on-demand native scratch segments for the FFM out-buffers that the column reader
+ * passes to the native page-decode / value-read functions.
+ *
+ * <h2>Named slots</h2>
+ * Buffers are keyed by a caller-chosen <em>slot</em> name (for example {@code "value"},
+ * {@code "presence"}, {@code "offsets"}). Each slot retains a single backing segment that
+ * grows monotonically to the largest size ever requested for that slot — so steady-state
+ * page decoding reuses the same native memory with no per-call allocation. A request for a
+ * size that still fits the slot's current backing segment returns that same segment (sliced
+ * to the requested length); a larger request replaces the backing segment.
+ *
+ * <p>Because doc IDs arrive ascending and a producer is single-threaded (one segment per
+ * query thread), a pool shared across a producer's column readers needs no synchronization.
+ * {@link #close()} frees every slot at once (the "release" step).
+ *
+ * <p>Callers must re-fetch (not cache across calls) a slot's segment, since a growth event
+ * replaces it. Returned segments are owned by the pool and must not be freed by callers.
+ */
+public final class BufferPool implements AutoCloseable {
+
+    private static final Logger logger = LogManager.getLogger(BufferPool.class);
+
+    /** A pooled slot: its backing segment and the byte capacity that segment was sized to. */
+    private static final class Slot {
+        MemorySegment segment;
+        long capacity;
+    }
+
+    private final Arena arena = Arena.ofConfined();
+    private final Map<String, Slot> slots = new HashMap<>();
+    private boolean closed;
+
+    // Layer 5 diagnostics: how often a slot request was served from the existing backing
+    // segment (reuse) vs forced a (re)allocation (grow). High reuse = the pool is doing its job.
+    private long reuseCount;
+    private long growCount;
+
+    /**
+     * Returns the named slot's segment, grown if necessary to hold at least {@code byteSize}
+     * bytes (minimum 1). The returned segment may be larger than requested; callers slice it
+     * to the exact length they need.
+     */
+    public MemorySegment bytes(String slot, long byteSize) {
+        ensureOpen();
+        long needed = Math.max(byteSize, 1);
+        Slot s = slots.computeIfAbsent(slot, k -> new Slot());
+        if (s.segment == null || s.capacity < needed) {
+            // Grow geometrically to avoid repeated resizes as pages get larger.
+            long newCap = s.capacity == 0 ? needed : Math.max(needed, s.capacity * 2);
+            s.segment = arena.allocate(newCap);
+            s.capacity = newCap;
+            growCount++;
+        } else {
+            reuseCount++;
+        }
+        return s.segment;
+    }
+
+    /** Returns the named slot's segment sized for at least {@code count} {@code long} slots. */
+    public MemorySegment longs(String slot, long count) {
+        return bytes(slot, Math.max(count, 1) * ValueLayout.JAVA_LONG.byteSize());
+    }
+
+    /** Returns the named slot's segment sized for at least {@code count} {@code int} slots. */
+    public MemorySegment ints(String slot, long count) {
+        return bytes(slot, Math.max(count, 1) * ValueLayout.JAVA_INT.byteSize());
+    }
+
+    /**
+     * Returns the named slot's segment sized for exactly one {@code long} out-pointer. Each
+     * distinct name gets its own stable single-long scratch cell, reused across calls.
+     */
+    public MemorySegment longOut(String slot) {
+        return bytes(slot, ValueLayout.JAVA_LONG.byteSize());
+    }
+
+    /** Number of distinct slots currently backed by a segment (for tests / diagnostics). */
+    public int slotCount() {
+        return slots.size();
+    }
+
+    /** Layer 5 diagnostics: requests served from an existing backing segment (no allocation). */
+    public long reuseCount() {
+        return reuseCount;
+    }
+
+    /** Layer 5 diagnostics: requests that forced a (re)allocation of a slot's backing segment. */
+    public long growCount() {
+        return growCount;
+    }
+
+    /** Layer 5 reuse rate in [0,1]; 0 when there were no requests. */
+    public double reuseRate() {
+        long total = reuseCount + growCount;
+        return total == 0 ? 0.0 : (double) reuseCount / total;
+    }
+
+    /** Single-line Layer 5 summary suitable for an INFO log. */
+    public String summary() {
+        return String.format(
+            java.util.Locale.ROOT,
+            "L5 buffer-pool: slots=%d reuse=%d grow=%d (reuseRate=%.2f%%)",
+            slots.size(),
+            reuseCount,
+            growCount,
+            reuseRate() * 100.0
+        );
+    }
+
+    /** Alias for {@link #close()}, matching the design's "release" vocabulary. */
+    public void release() {
+        close();
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new IllegalStateException("BufferPool already closed");
+        }
+    }
+
+    @Override
+    public void close() {
+        if (closed == false) {
+            closed = true;
+            if (reuseCount + growCount > 0 && logger.isDebugEnabled()) {
+                // Benchmarking: demoted from info to debug so per-query buffer-pool stats
+                // are not emitted during raw-performance runs.
+                logger.debug("[PARQUET_DV_CACHE_STATS] {}", summary());
+            }
+            slots.clear();
+            arena.close();
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/CacheStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/CacheStats.java
@@ -45,6 +45,11 @@ public final class CacheStats {
     private long slowValueReads;    // parquet_read_value_at_row (single)
     private long slowRepeatedReads; // parquet_read_repeated_at_row
 
+    // Prefetch — async decode of the next sequential page.
+    private long prefetchSubmitted;  // times a prefetch was kicked off
+    private long prefetchHits;       // times the next miss was served by a landed prefetch
+    private long prefetchWaste;      // times a prefetch result was discarded (non-sequential jump)
+
     // Section timings (nanoseconds), to attribute query latency to a specific phase.
     private long pageDecodeNanos;    // time inside the FFM page decode
     private long pageIndexLoadNanos; // time building the Layer 3 ColumnPageIndex at reader open
@@ -93,6 +98,30 @@ public final class CacheStats {
     /** Records an FFM slow-path repeated-value read crossing. */
     public void slowRepeatedRead() {
         slowRepeatedReads++;
+    }
+
+    public void prefetchSubmitted() {
+        prefetchSubmitted++;
+    }
+
+    public void prefetchHit() {
+        prefetchHits++;
+    }
+
+    public void prefetchWaste() {
+        prefetchWaste++;
+    }
+
+    public long prefetchSubmittedCount() {
+        return prefetchSubmitted;
+    }
+
+    public long prefetchHitCount() {
+        return prefetchHits;
+    }
+
+    public long prefetchWasteCount() {
+        return prefetchWaste;
     }
 
     /** Adds elapsed nanoseconds spent inside an FFM page decode. */
@@ -185,6 +214,7 @@ public final class CacheStats {
             Locale.ROOT,
             "L1/2 page-cache: hits=%d misses=%d (hitRate=%.2f%%) | L3 jumpTableLookups=%d | "
                 + "L4 allNullSkips=%d | FFM: pageDecodes=%d slowValueReads=%d slowRepeatedReads=%d (totalCrossings=%d) | "
+                + "prefetch: submitted=%d hits=%d waste=%d | "
                 + "timings(ms): pageDecode=%.1f pageIndexLoad=%.1f slowRead=%.1f | "
                 + "values: present=%d absent=%d",
             pageCacheHits,
@@ -196,6 +226,9 @@ public final class CacheStats {
             slowValueReads,
             slowRepeatedReads,
             ffmCrossings(),
+            prefetchSubmitted,
+            prefetchHits,
+            prefetchWaste,
             pageDecodeNanos / 1_000_000.0,
             pageIndexLoadNanos / 1_000_000.0,
             slowReadNanos / 1_000_000.0,

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/CacheStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/CacheStats.java
@@ -1,0 +1,206 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+import java.util.Locale;
+
+/**
+ * Per-column hit/miss counters for the Parquet DocValues cache layers, used to measure how much
+ * each caching layer contributes during a query. One instance is owned by each
+ * {@code ParquetColumnReader}; it is single-threaded (one segment per query thread), so counters
+ * are plain {@code long}s with no synchronization.
+ *
+ * <p>Layer mapping (per the codec design):
+ * <ul>
+ *   <li><b>Layer 1/2</b> — page-resident value + presence cache. A <em>hit</em> is a row served from
+ *       the currently resident {@link PageCache} with no FFM call; a <em>miss</em> triggers a page load.</li>
+ *   <li><b>Layer 3</b> — OffsetIndex jump table ({@code pageForRow} binary search), consulted on every miss.</li>
+ *   <li><b>Layer 4</b> — page-stat all-nulls skip; a miss resolved without decoding the page.</li>
+ *   <li><b>FFM</b> — calls that cross the native boundary (page decodes and slow-path single/repeated
+ *       reads). This is the cost the upper layers exist to avoid.</li>
+ * </ul>
+ */
+public final class CacheStats {
+
+    // Layer 1/2 — page-resident value + presence cache.
+    private long pageCacheHits;
+    private long pageCacheMisses;
+    private long presentValues;   // rows that resolved to a non-null value (data, not caching)
+    private long absentValues;    // rows that resolved to null
+
+    // Layer 3 — OffsetIndex jump-table lookups (one per miss).
+    private long pageIndexLookups;
+
+    // Layer 4 — all-nulls page skips (a miss resolved with no decode).
+    private long allNullPageSkips;
+
+    // FFM boundary crossings.
+    private long pageDecodes;       // parquet_decode_page_at_row
+    private long slowValueReads;    // parquet_read_value_at_row (single)
+    private long slowRepeatedReads; // parquet_read_repeated_at_row
+
+    // Section timings (nanoseconds), to attribute query latency to a specific phase.
+    private long pageDecodeNanos;    // time inside the FFM page decode
+    private long pageIndexLoadNanos; // time building the Layer 3 ColumnPageIndex at reader open
+    private long slowReadNanos;      // time inside slow-path single/repeated FFM reads
+
+    /** Records a Layer 1/2 page-cache hit (row served from the resident page, no FFM). */
+    public void pageCacheHit() {
+        pageCacheHits++;
+    }
+
+    /** Records a Layer 1/2 page-cache miss (a page load is required). */
+    public void pageCacheMiss() {
+        pageCacheMisses++;
+    }
+
+    /** Records that a resolved row had a present (non-null) value. */
+    public void present() {
+        presentValues++;
+    }
+
+    /** Records that a resolved row was null/absent. */
+    public void absent() {
+        absentValues++;
+    }
+
+    /** Records a Layer 3 jump-table lookup ({@code pageForRow}). */
+    public void pageIndexLookup() {
+        pageIndexLookups++;
+    }
+
+    /** Records a Layer 4 all-nulls page skip (miss resolved without a decode). */
+    public void allNullPageSkip() {
+        allNullPageSkips++;
+    }
+
+    /** Records an FFM page decode crossing. */
+    public void pageDecode() {
+        pageDecodes++;
+    }
+
+    /** Records an FFM slow-path single-value read crossing. */
+    public void slowValueRead() {
+        slowValueReads++;
+    }
+
+    /** Records an FFM slow-path repeated-value read crossing. */
+    public void slowRepeatedRead() {
+        slowRepeatedReads++;
+    }
+
+    /** Adds elapsed nanoseconds spent inside an FFM page decode. */
+    public void addPageDecodeNanos(long nanos) {
+        pageDecodeNanos += nanos;
+    }
+
+    /** Adds elapsed nanoseconds spent building the Layer 3 page index at reader open. */
+    public void addPageIndexLoadNanos(long nanos) {
+        pageIndexLoadNanos += nanos;
+    }
+
+    /** Adds elapsed nanoseconds spent inside a slow-path single/repeated FFM read. */
+    public void addSlowReadNanos(long nanos) {
+        slowReadNanos += nanos;
+    }
+
+    public long pageCacheHits() {
+        return pageCacheHits;
+    }
+
+    public long pageCacheMisses() {
+        return pageCacheMisses;
+    }
+
+    public long pageDecodes() {
+        return pageDecodes;
+    }
+
+    public long allNullPageSkips() {
+        return allNullPageSkips;
+    }
+
+    public long pageIndexLookups() {
+        return pageIndexLookups;
+    }
+
+    public long presentValues() {
+        return presentValues;
+    }
+
+    public long absentValues() {
+        return absentValues;
+    }
+
+    public long slowValueReads() {
+        return slowValueReads;
+    }
+
+    public long slowRepeatedReads() {
+        return slowRepeatedReads;
+    }
+
+    public long pageDecodeNanos() {
+        return pageDecodeNanos;
+    }
+
+    public long pageIndexLoadNanos() {
+        return pageIndexLoadNanos;
+    }
+
+    public long slowReadNanos() {
+        return slowReadNanos;
+    }
+
+    /** Total page-cache lookups (hits + misses). */
+    public long pageCacheLookups() {
+        return pageCacheHits + pageCacheMisses;
+    }
+
+    /** Layer 1/2 hit rate in [0,1]; 0 when there were no lookups. */
+    public double pageCacheHitRate() {
+        long total = pageCacheLookups();
+        return total == 0 ? 0.0 : (double) pageCacheHits / total;
+    }
+
+    /** Total FFM boundary crossings across all access paths. */
+    public long ffmCrossings() {
+        return pageDecodes + slowValueReads + slowRepeatedReads;
+    }
+
+    /** True when no access has been recorded (used to suppress empty summaries). */
+    public boolean isEmpty() {
+        return pageCacheLookups() == 0 && slowValueReads == 0 && slowRepeatedReads == 0;
+    }
+
+    /** A single-line, human-readable summary suitable for an INFO log on reader close. */
+    public String summary() {
+        return String.format(
+            Locale.ROOT,
+            "L1/2 page-cache: hits=%d misses=%d (hitRate=%.2f%%) | L3 jumpTableLookups=%d | "
+                + "L4 allNullSkips=%d | FFM: pageDecodes=%d slowValueReads=%d slowRepeatedReads=%d (totalCrossings=%d) | "
+                + "timings(ms): pageDecode=%.1f pageIndexLoad=%.1f slowRead=%.1f | "
+                + "values: present=%d absent=%d",
+            pageCacheHits,
+            pageCacheMisses,
+            pageCacheHitRate() * 100.0,
+            pageIndexLookups,
+            allNullPageSkips,
+            pageDecodes,
+            slowValueReads,
+            slowRepeatedReads,
+            ffmCrossings(),
+            pageDecodeNanos / 1_000_000.0,
+            pageIndexLoadNanos / 1_000_000.0,
+            slowReadNanos / 1_000_000.0,
+            presentValues,
+            absentValues
+        );
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/ColumnPageIndex.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/ColumnPageIndex.java
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+/**
+ * Layer 3 (jump table) + Layer 4 (page-stat skip) — an in-memory, binary-searchable view
+ * of a column's Parquet OffsetIndex + ColumnIndex. Built once per {@code (segment, column)}
+ * when the column reader is opened, from the parallel arrays returned by the native
+ * {@code parquet_get_column_page_index} call.
+ *
+ * <p>Parallel arrays are indexed by page. {@code firstRowOf} is ascending with
+ * {@code firstRowOf[0] == 0}; the number of rows in page {@code p} is
+ * {@code firstRowOf[p+1] - firstRowOf[p]} (or {@code totalRows - firstRowOf[p]} for the
+ * last page).
+ *
+ * <p>This is the task-3 (Layer 3/4) structure; the column-reader wrapper (task 2) builds
+ * and owns it, so it is introduced here. Task 3 refines and adds dedicated unit tests.
+ */
+public final class ColumnPageIndex {
+
+    private final long[] firstRowOf;
+    private final long[] fileOffsetOf;
+    private final int[] compressedSizeOf;
+    private final long[] nullCountOf;
+    private final long[] minOf;
+    private final long[] maxOf;
+    private final long totalRows;
+
+    public ColumnPageIndex(
+        long[] firstRowOf,
+        long[] fileOffsetOf,
+        int[] compressedSizeOf,
+        long[] nullCountOf,
+        long[] minOf,
+        long[] maxOf,
+        long totalRows
+    ) {
+        int n = firstRowOf.length;
+        if (fileOffsetOf.length != n || compressedSizeOf.length != n || nullCountOf.length != n || minOf.length != n || maxOf.length != n) {
+            throw new IllegalArgumentException("ColumnPageIndex parallel arrays must have equal length");
+        }
+        this.firstRowOf = firstRowOf;
+        this.fileOffsetOf = fileOffsetOf;
+        this.compressedSizeOf = compressedSizeOf;
+        this.nullCountOf = nullCountOf;
+        this.minOf = minOf;
+        this.maxOf = maxOf;
+        this.totalRows = totalRows;
+    }
+
+    /** Number of pages. */
+    public int pageCount() {
+        return firstRowOf.length;
+    }
+
+    /** Global index of the first row of page {@code p}. */
+    public long firstRowOf(int p) {
+        return firstRowOf[p];
+    }
+
+    /** Number of rows in page {@code p}. */
+    public long numRowsOf(int p) {
+        long next = (p + 1 < firstRowOf.length) ? firstRowOf[p + 1] : totalRows;
+        return next - firstRowOf[p];
+    }
+
+    /** File byte offset of page {@code p} (0 when unknown). */
+    public long fileOffsetOf(int p) {
+        return fileOffsetOf[p];
+    }
+
+    /** Compressed size of page {@code p} in bytes (0 when unknown). */
+    public int compressedSizeOf(int p) {
+        return compressedSizeOf[p];
+    }
+
+    /** Null count of page {@code p}, or -1 when unknown. */
+    public long nullCountOf(int p) {
+        return nullCountOf[p];
+    }
+
+    /** Per-page min value raw bits (numeric columns only; 0 otherwise). */
+    public long minOf(int p) {
+        return minOf[p];
+    }
+
+    /** Per-page max value raw bits (numeric columns only; 0 otherwise). */
+    public long maxOf(int p) {
+        return maxOf[p];
+    }
+
+    /** Total number of rows across all pages. */
+    public long totalRows() {
+        return totalRows;
+    }
+
+    /**
+     * Binary search: returns the page index containing global row {@code row}, or -1 when
+     * {@code row} is out of range. O(log P).
+     */
+    public int pageForRow(long row) {
+        if (row < 0 || row >= totalRows) {
+            return -1;
+        }
+        int lo = 0;
+        int hi = firstRowOf.length - 1;
+        // Find the highest page whose firstRow <= row.
+        while (lo <= hi) {
+            int mid = (lo + hi) >>> 1;
+            if (firstRowOf[mid] <= row) {
+                lo = mid + 1;
+            } else {
+                hi = mid - 1;
+            }
+        }
+        return hi; // hi is the last page with firstRow <= row
+    }
+
+    /**
+     * Layer 4 fast path: true when page {@code p} is known to be entirely nulls
+     * ({@code nullCount == rowsInPage}). Returns false when the null count is unknown (-1).
+     */
+    public boolean isAllNulls(int p) {
+        long nc = nullCountOf[p];
+        return nc >= 0 && nc == numRowsOf(p);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/PageCache.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/PageCache.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+/**
+ * Layer 1 (page-resident value cache) + Layer 2 (page-resident presence bitset) for a
+ * single decoded Parquet page of a single-valued column.
+ *
+ * <p>Holds the inclusive global row range {@code [firstRow, lastRow]}, the decoded values
+ * (raw {@code long} bits for primitives, or a backing byte buffer + CSR offsets for
+ * {@code BYTE_ARRAY}), and a packed presence bitset with one bit per row in the page.
+ * Iterators serve cache hits with a presence bit-test plus an array index lookup — no FFM
+ * call. A single instance per column is resident at a time (sliding window, ascending
+ * doc IDs, no LRU).
+ *
+ * <p>This is the task-3 (Layer 1/2) structure; the column-reader wrapper (task 2) populates
+ * and owns it, so it is introduced here. Task 3 refines and adds dedicated unit tests.
+ */
+public final class PageCache {
+
+    /** Inclusive global index of the first row in the cached page. */
+    public long firstRow;
+    /** Inclusive global index of the last row in the cached page. */
+    public long lastRow;
+
+    /** Decoded raw bits, one slot per row (primitive columns). Null for binary columns. */
+    public long[] values;
+
+    /** Backing byte buffer for binary columns (concatenated value bytes). Null for primitives. */
+    public byte[] byteBuf;
+    /** CSR offsets into {@link #byteBuf}, length {@code rowsInPage + 1}. Null for primitives. */
+    public int[] byteOffsets;
+
+    /** Packed presence bitset: bit {@code i} set when row {@code firstRow + i} is non-null. */
+    public long[] presenceBits;
+
+    /** Number of rows in the cached page. */
+    public int rowCount() {
+        return (int) (lastRow - firstRow + 1);
+    }
+
+    /**
+     * Constant-time presence test for a global row that lies within {@code [firstRow, lastRow]}.
+     */
+    public boolean isPresent(long row) {
+        int idx = (int) (row - firstRow);
+        return (presenceBits[idx >> 6] & (1L << (idx & 63))) != 0L;
+    }
+
+    /** Returns the raw {@code long} bits for a primitive value at the given global row. */
+    public long valueAt(long row) {
+        return values[(int) (row - firstRow)];
+    }
+
+    /** True when the given global row falls within this cached page's range. */
+    public boolean contains(long row) {
+        return row >= firstRow && row <= lastRow;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/PageCache.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/PageCache.java
@@ -8,6 +8,9 @@
 
 package org.opensearch.parquet.codec.cache;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
 /**
  * Layer 1 (page-resident value cache) + Layer 2 (page-resident presence bitset) for a
  * single decoded Parquet page of a single-valued column.
@@ -15,9 +18,18 @@ package org.opensearch.parquet.codec.cache;
  * <p>Holds the inclusive global row range {@code [firstRow, lastRow]}, the decoded values
  * (raw {@code long} bits for primitives, or a backing byte buffer + CSR offsets for
  * {@code BYTE_ARRAY}), and a packed presence bitset with one bit per row in the page.
- * Iterators serve cache hits with a presence bit-test plus an array index lookup — no FFM
+ * Iterators serve cache hits with a presence bit-test plus an index lookup — no FFM
  * call. A single instance per column is resident at a time (sliding window, ascending
  * doc IDs, no LRU).
+ *
+ * <p><b>Zero-copy primitive values.</b> For primitive columns {@link #values} references the
+ * off-heap {@link MemorySegment} that the native decode wrote into <em>directly</em> — the
+ * page's decoded {@code long}s are read in place via {@link #valueAt(long)} rather than copied
+ * into a heap {@code long[]}. This is safe only because the backing segment is a
+ * <em>per-column</em> pool slot (see {@code ParquetColumnReader.decodePage}): the segment a
+ * cache holds is never reused by another column, and this column's own next page decode does
+ * not run until this cache is replaced. Presence bits and the binary byte buffer are still
+ * copied to the heap (small, and the binary path hands a {@code byte[]} to a {@code BytesRef}).
  *
  * <p>This is the task-3 (Layer 1/2) structure; the column-reader wrapper (task 2) populates
  * and owns it, so it is introduced here. Task 3 refines and adds dedicated unit tests.
@@ -29,8 +41,12 @@ public final class PageCache {
     /** Inclusive global index of the last row in the cached page. */
     public long lastRow;
 
-    /** Decoded raw bits, one slot per row (primitive columns). Null for binary columns. */
-    public long[] values;
+    /**
+     * Decoded raw bits, one {@code long} slot per row (primitive columns); {@code null} for
+     * binary columns. This is an off-heap segment owned by the column's buffer-pool slot,
+     * sliced to exactly {@code rowCount()} longs — read in place, never copied.
+     */
+    public MemorySegment values;
 
     /** Backing byte buffer for binary columns (concatenated value bytes). Null for primitives. */
     public byte[] byteBuf;
@@ -55,7 +71,7 @@ public final class PageCache {
 
     /** Returns the raw {@code long} bits for a primitive value at the given global row. */
     public long valueAt(long row) {
-        return values[(int) (row - firstRow)];
+        return values.getAtIndex(ValueLayout.JAVA_LONG, row - firstRow);
     }
 
     /** True when the given global row falls within this cached page's range. */

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/QueryParquetStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/QueryParquetStats.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+import java.util.Locale;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Query-scoped accumulator that sums per-column {@link CacheStats} across every segment touched by
+ * a single search, so the Parquet read-path cost can be summarized in one log line per query.
+ *
+ * <p>One instance is created per search (by {@code ParquetDocValuesDirectoryReader}) and shared by
+ * all the per-segment {@code ParquetColumnReader}s that search opens. Each column reader
+ * {@link #register(CacheStats) registers} its {@link CacheStats} when it is opened; the values are
+ * summed <b>live</b> at {@link #summary()} time. Registering at open (rather than merging at close)
+ * means the roll-up does not depend on reader-close ordering — by the time the per-query summary is
+ * produced (end of search), every registered reader has finished collecting, so the live sums are
+ * final. The registry is a {@link ConcurrentLinkedQueue} so concurrent segment slices can register
+ * safely, and each reader mutates only its own {@link CacheStats} during collection.
+ */
+public final class QueryParquetStats {
+
+    private final ConcurrentLinkedQueue<CacheStats> registered = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<RowIdStats> rowIdRegistered = new ConcurrentLinkedQueue<>();
+    private final LongAdder producerSetupNanos = new LongAdder();
+    private final LongAdder readerOpenNanos = new LongAdder();
+    private final LongAdder readerCloseNanos = new LongAdder();
+
+    /** Registers a column reader's stats; its counters are summed live when {@link #summary()} runs. */
+    public void register(CacheStats s) {
+        if (s != null) {
+            registered.add(s);
+        }
+    }
+
+    /** Registers a resolver's docId&rarr;row translation stats; summed live at {@link #summary()}. */
+    public void registerRowId(RowIdStats s) {
+        if (s != null) {
+            rowIdRegistered.add(s);
+        }
+    }
+
+    /** Adds time spent constructing a producer (file resolve + metadata read) for one segment. */
+    public void addProducerSetupNanos(long nanos) {
+        producerSetupNanos.add(nanos);
+    }
+
+    /** Adds time spent in the native {@code openColumnReader} FFM crossing (once per column). */
+    public void addReaderOpenNanos(long nanos) {
+        readerOpenNanos.add(nanos);
+    }
+
+    /** Adds time spent in the native {@code closeColumnReader} FFM crossing (once per column). */
+    public void addReaderCloseNanos(long nanos) {
+        readerCloseNanos.add(nanos);
+    }
+
+    /** True when nothing was recorded (used to suppress an empty summary). */
+    public boolean isEmpty() {
+        return registered.isEmpty() && rowIdRegistered.isEmpty() && producerSetupNanos.sum() == 0;
+    }
+
+    /** A single-line, human-readable per-query summary. */
+    public String summary() {
+        long columns = 0;
+        long hits = 0, misses = 0, present = 0, absent = 0;
+        long jumpTableLookups = 0, allNullSkips = 0;
+        long pageDecodes = 0, slowValueReads = 0, slowRepeatedReads = 0;
+        long pageDecodeNanos = 0, pageIndexLoadNanos = 0, slowReadNanos = 0;
+        for (CacheStats s : registered) {
+            columns++;
+            hits += s.pageCacheHits();
+            misses += s.pageCacheMisses();
+            present += s.presentValues();
+            absent += s.absentValues();
+            jumpTableLookups += s.pageIndexLookups();
+            allNullSkips += s.allNullPageSkips();
+            pageDecodes += s.pageDecodes();
+            slowValueReads += s.slowValueReads();
+            slowRepeatedReads += s.slowRepeatedReads();
+            pageDecodeNanos += s.pageDecodeNanos();
+            pageIndexLoadNanos += s.pageIndexLoadNanos();
+            slowReadNanos += s.slowReadNanos();
+        }
+        // RowId docId->row translation layer. COUNTS ONLY — the per-doc time is not code-timed
+        // (it is too hot to measure accurately); obtain its wall-clock from a CPU flamegraph.
+        long rowIdResolvers = 0, rowIdIdentity = 0, rowIdLookups = 0;
+        for (RowIdStats r : rowIdRegistered) {
+            rowIdResolvers++;
+            if (r.isIdentity()) {
+                rowIdIdentity++;
+            }
+            rowIdLookups += r.lookups();
+        }
+
+        long lookups = hits + misses;
+        double hitRate = lookups == 0 ? 0.0 : (double) hits / lookups * 100.0;
+        double decodeMs = pageDecodeNanos / 1_000_000.0;
+        double indexLoadMs = pageIndexLoadNanos / 1_000_000.0;
+        double slowReadMs = slowReadNanos / 1_000_000.0;
+        double setupMs = producerSetupNanos.sum() / 1_000_000.0;
+        double readerOpenMs = readerOpenNanos.sum() / 1_000_000.0;
+        double readerCloseMs = readerCloseNanos.sum() / 1_000_000.0;
+        // Sum of the accurately-measured coarse sections only (excludes the un-timed per-doc loop).
+        double measuredParquetMs = decodeMs + indexLoadMs + slowReadMs + setupMs + readerOpenMs + readerCloseMs;
+        return String.format(
+            Locale.ROOT,
+            "segments/columns=%d | L1/2 cache: hits=%d misses=%d (hitRate=%.2f%%) | "
+                + "L3 jumpTableLookups=%d | L4 allNullSkips=%d | "
+                + "FFM: pageDecodes=%d slowValueReads=%d slowRepeatedReads=%d | "
+                + "RowId: resolvers=%d identity=%d lookups=%d (time via flamegraph) | "
+                + "timings(ms): pageDecode=%.1f pageIndexLoad=%.1f slowRead=%.1f "
+                + "readerOpen=%.1f readerClose=%.1f producerSetup=%.1f measuredParquetTime=%.1f | "
+                + "values: present=%d absent=%d",
+            columns,
+            hits,
+            misses,
+            hitRate,
+            jumpTableLookups,
+            allNullSkips,
+            pageDecodes,
+            slowValueReads,
+            slowRepeatedReads,
+            rowIdResolvers,
+            rowIdIdentity,
+            rowIdLookups,
+            decodeMs,
+            indexLoadMs,
+            slowReadMs,
+            readerOpenMs,
+            readerCloseMs,
+            setupMs,
+            measuredParquetMs,
+            present,
+            absent
+        );
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/RowIdStats.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/RowIdStats.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+/**
+ * Per-resolver counters for the docId&rarr;Parquet-row translation layer (the
+ * {@code RowIdRemappingDocValues} resolver backed by {@code __row_id__}).
+ *
+ * <p>One instance is created per codec DocValues iterator (each builds its own resolver), so this is
+ * single-threaded for the lifetime of one iterator &mdash; counters are plain {@code long}s with no
+ * synchronization, mirroring {@link CacheStats}. It is registered once with the query-scoped
+ * {@code QueryParquetStats} and summed live at end of query.
+ *
+ * <h2>Counts only &mdash; no per-call timing</h2>
+ * Only <b>counts</b> are tracked here ({@link #lookups()} and the {@link #isIdentity() identity}
+ * flag), never per-call time. {@code toRowId(docId)} runs once per document (up to 100M+ times per
+ * query); the work per call is on the order of tens of nanoseconds, comparable to
+ * {@code System.nanoTime()} itself, so code-timing each call cannot produce a trustworthy figure
+ * (it inflates and, when extrapolated, exceeds the whole query time). The honest signal is the
+ * exact lookup <b>count</b> here; the actual wall-clock spent in this layer is obtained from a CPU
+ * flamegraph (async-profiler), which attributes real per-method time without instrumentation
+ * overhead.
+ */
+public final class RowIdStats {
+
+    /** True when this resolver is the no-op IDENTITY mapping (segment has docId == rowId). */
+    private boolean identity;
+
+    /** Number of {@code toRowId} calls that performed a {@code __row_id__} lookup. */
+    private long lookups;
+
+    /** Marks this resolver as the IDENTITY (no-op) mapping. */
+    public void markIdentity() {
+        identity = true;
+    }
+
+    /** Records one {@code __row_id__} lookup (called per document on a backed resolver). */
+    public void recordLookup() {
+        lookups++;
+    }
+
+    public boolean isIdentity() {
+        return identity;
+    }
+
+    public long lookups() {
+        return lookups;
+    }
+
+    /** True when this resolver did no work (not used / no lookups and not marked identity). */
+    public boolean isEmpty() {
+        return identity == false && lookups == 0;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/package-info.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/cache/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Layered cache structures for the Parquet DocValues codec.
+ *
+ * <ul>
+ *   <li>{@link org.opensearch.parquet.codec.cache.BufferPool} — Layer 5, reusable native
+ *       scratch buffers for FFM out-parameters.</li>
+ *   <li>{@link org.opensearch.parquet.codec.cache.ColumnPageIndex} — Layer 3 jump table +
+ *       Layer 4 page-stat skip, a binary-searchable view of the Parquet page index.</li>
+ *   <li>{@link org.opensearch.parquet.codec.cache.PageCache} — Layer 1 page-resident value
+ *       cache + Layer 2 presence bitset for one decoded page.</li>
+ * </ul>
+ */
+package org.opensearch.parquet.codec.cache;

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetBinaryDocValues.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetBinaryDocValues.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.iter;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.parquet.bridge.ParquetColumnReader;
+import org.opensearch.parquet.codec.cache.PageCache;
+
+import java.io.IOException;
+
+/**
+ * Cache-aware {@link BinaryDocValues} over a single-valued Parquet {@code BYTE_ARRAY} column.
+ *
+ * <p>Hot path: a presence bit-test plus a CSR-offset slice into the cached page's backing
+ * byte buffer. The returned {@link BytesRef} is a single reused instance whose
+ * {@code bytes}/{@code offset}/{@code length} are repointed each call (Layer 5). UTF-8 bytes
+ * are preserved byte-for-byte.
+ */
+public final class ParquetBinaryDocValues extends BinaryDocValues {
+
+    private final ParquetColumnReader reader;
+    private final int maxDoc;
+    private final BytesRef scratch = new BytesRef();
+
+    private int doc = -1;
+    private boolean currentPresent;
+
+    public ParquetBinaryDocValues(ParquetColumnReader reader, int maxDoc) {
+        this.reader = reader;
+        this.maxDoc = maxDoc;
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        if (target >= maxDoc) {
+            doc = NO_MORE_DOCS;
+            currentPresent = false;
+            return false;
+        }
+        doc = target;
+        PageCache cache = reader.cache();
+        if (cache != null && target <= cache.lastRow && target >= cache.firstRow) {
+            // Layer 1/2 hit — served from the resident page, no FFM crossing.
+        } else {
+            // Layer 1/2 miss — load the page containing this row (Layer 3 → 4 → FFM).
+            reader.loadPageContaining(target);
+            cache = reader.cache();
+            if (cache == null) { // Layer 4: page is all-nulls.
+                currentPresent = false;
+                return false;
+            }
+        }
+        currentPresent = cache.isPresent(target);
+        if (currentPresent) {
+            int rel = (int) (target - cache.firstRow);
+            int start = cache.byteOffsets[rel];
+            int end = cache.byteOffsets[rel + 1];
+            scratch.bytes = cache.byteBuf;
+            scratch.offset = start;
+            scratch.length = end - start;
+        }
+        return currentPresent;
+    }
+
+    @Override
+    public BytesRef binaryValue() {
+        return scratch;
+    }
+
+    @Override
+    public int docID() {
+        return doc;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return advance(doc + 1);
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        for (int d = target; d < maxDoc; d++) {
+            if (advanceExact(d)) {
+                doc = d;
+                return d;
+            }
+        }
+        doc = NO_MORE_DOCS;
+        return NO_MORE_DOCS;
+    }
+
+    @Override
+    public long cost() {
+        return maxDoc;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetNumericDocValues.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetNumericDocValues.java
@@ -1,0 +1,97 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.iter;
+
+import org.apache.lucene.index.NumericDocValues;
+import org.opensearch.parquet.bridge.ParquetColumnReader;
+import org.opensearch.parquet.codec.cache.PageCache;
+
+import java.io.IOException;
+
+/**
+ * Cache-aware {@link NumericDocValues} over a single-valued Parquet primitive column.
+ *
+ * <p>Hot path: a presence bit-test plus a {@code long[]} index lookup against the column
+ * reader's current {@link PageCache}. Cold path (page miss): {@link ParquetColumnReader#loadPageContaining}
+ * decodes the page (or applies the Layer 4 all-nulls skip). Float/double values are stored as
+ * raw IEEE-754 bits at page-decode time, so {@link #longValue()} returns the Lucene-encoded
+ * form directly.
+ */
+public final class ParquetNumericDocValues extends NumericDocValues {
+
+    private final ParquetColumnReader reader;
+    private final int maxDoc;
+
+    private int doc = -1;
+    private long currentValue;
+    private boolean currentPresent;
+
+    public ParquetNumericDocValues(ParquetColumnReader reader, int maxDoc) {
+        this.reader = reader;
+        this.maxDoc = maxDoc;
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        if (target >= maxDoc) {
+            doc = NO_MORE_DOCS;
+            currentPresent = false;
+            return false;
+        }
+        doc = target;
+        PageCache cache = reader.cache();
+        if (cache != null && target <= cache.lastRow && target >= cache.firstRow) {
+            // Layer 1/2 hit — served from the resident page, no FFM crossing.
+        } else {
+            // Layer 1/2 miss — load the page containing this row (Layer 3 → 4 → FFM).
+            reader.loadPageContaining(target);
+            cache = reader.cache();
+            if (cache == null) { // Layer 4: page is all-nulls.
+                currentPresent = false;
+                currentValue = 0L;
+                return false;
+            }
+        }
+        currentPresent = cache.isPresent(target);
+        currentValue = currentPresent ? cache.valueAt(target) : 0L;
+        return currentPresent;
+    }
+
+    @Override
+    public long longValue() {
+        return currentValue;
+    }
+
+    @Override
+    public int docID() {
+        return doc;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return advance(doc + 1);
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        for (int d = target; d < maxDoc; d++) {
+            if (advanceExact(d)) {
+                doc = d;
+                return d;
+            }
+        }
+        doc = NO_MORE_DOCS;
+        return NO_MORE_DOCS;
+    }
+
+    @Override
+    public long cost() {
+        return maxDoc;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetSortedDocValues.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetSortedDocValues.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.iter;
+
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.parquet.codec.OrdinalTable;
+
+import java.io.IOException;
+
+/**
+ * {@link SortedDocValues} backed by a per-segment {@link OrdinalTable} for a single-valued
+ * Parquet keyword/ip column. The ordinal table is built once (lazily) by the producer; this
+ * iterator only walks the per-row ordinal array and serves {@code lookupOrd} from the sorted
+ * term dictionary.
+ */
+public final class ParquetSortedDocValues extends SortedDocValues {
+
+    private final OrdinalTable table;
+    private final int maxDoc;
+
+    private int doc = -1;
+    private int currentOrd = -1;
+
+    public ParquetSortedDocValues(OrdinalTable table, int maxDoc) {
+        this.table = table;
+        this.maxDoc = maxDoc;
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        if (target >= maxDoc) {
+            doc = NO_MORE_DOCS;
+            currentOrd = -1;
+            return false;
+        }
+        doc = target;
+        currentOrd = table.ordForRow(target);
+        return currentOrd != -1;
+    }
+
+    @Override
+    public int ordValue() {
+        return currentOrd;
+    }
+
+    @Override
+    public BytesRef lookupOrd(int ord) {
+        return table.lookupOrd(ord);
+    }
+
+    @Override
+    public int getValueCount() {
+        return table.valueCount();
+    }
+
+    @Override
+    public int docID() {
+        return doc;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return advance(doc + 1);
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        for (int d = target; d < maxDoc; d++) {
+            if (table.ordForRow(d) != -1) {
+                doc = d;
+                currentOrd = table.ordForRow(d);
+                return d;
+            }
+        }
+        doc = NO_MORE_DOCS;
+        currentOrd = -1;
+        return NO_MORE_DOCS;
+    }
+
+    @Override
+    public long cost() {
+        return maxDoc;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetSortedNumericDocValues.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetSortedNumericDocValues.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.iter;
+
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.opensearch.parquet.bridge.ParquetColumnReader;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * {@link SortedNumericDocValues} over a multi-valued Parquet primitive column.
+ *
+ * <p>Repeated columns are not page-cacheable (the page decoder targets single-valued
+ * columns), so each {@link #advanceExact(int)} reads the row's repeated values via the
+ * column reader's slow path, then sorts them ascending to satisfy Lucene's contract. The
+ * per-doc values are buffered in a reused array (Layer 5) and walked by {@link #nextValue()}.
+ */
+public final class ParquetSortedNumericDocValues extends SortedNumericDocValues {
+
+    private final ParquetColumnReader reader;
+    private final int maxDoc;
+
+    private int doc = -1;
+    private long[] values = new long[0];
+    private int count;
+    private int cursor;
+
+    public ParquetSortedNumericDocValues(ParquetColumnReader reader, int maxDoc) {
+        this.reader = reader;
+        this.maxDoc = maxDoc;
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        if (target >= maxDoc) {
+            doc = NO_MORE_DOCS;
+            count = 0;
+            cursor = 0;
+            return false;
+        }
+        doc = target;
+        ParquetColumnReader.RepeatedValues rv = reader.readRepeatedAtRow(target);
+        count = rv.count();
+        cursor = 0;
+        if (count == 0) {
+            return false; // empty list = missing.
+        }
+        if (values.length < count) {
+            values = new long[count];
+        }
+        System.arraycopy(rv.bits(), 0, values, 0, count);
+        // Lucene's SortedNumeric contract requires ascending order.
+        Arrays.sort(values, 0, count);
+        return true;
+    }
+
+    @Override
+    public int docValueCount() {
+        return count;
+    }
+
+    @Override
+    public long nextValue() {
+        return values[cursor++];
+    }
+
+    @Override
+    public int docID() {
+        return doc;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return advance(doc + 1);
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        for (int d = target; d < maxDoc; d++) {
+            if (advanceExact(d)) {
+                doc = d;
+                return d;
+            }
+        }
+        doc = NO_MORE_DOCS;
+        return NO_MORE_DOCS;
+    }
+
+    @Override
+    public long cost() {
+        return maxDoc;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetSortedSetDocValues.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/ParquetSortedSetDocValues.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.iter;
+
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.util.BytesRef;
+import org.opensearch.parquet.codec.OrdinalTable;
+
+import java.io.IOException;
+
+/**
+ * {@link SortedSetDocValues} backed by a per-segment {@link OrdinalTable} for a multi-valued
+ * Parquet keyword/ip column.
+ *
+ * <p>The ordinal table's CSR layout stores each row's distinct ordinals in ascending order.
+ * Following Lucene 10's contract, {@link #advanceExact(int)} returns {@code false} on an empty
+ * list, {@link #docValueCount()} reports the row's ordinal count, and {@link #nextOrd()} is
+ * called exactly {@code docValueCount()} times, returning strictly ascending ordinals.
+ */
+public final class ParquetSortedSetDocValues extends SortedSetDocValues {
+
+    private final OrdinalTable table;
+    private final int maxDoc;
+
+    private int doc = -1;
+    private int count;
+    private int cursor;
+
+    public ParquetSortedSetDocValues(OrdinalTable table, int maxDoc) {
+        this.table = table;
+        this.maxDoc = maxDoc;
+    }
+
+    @Override
+    public boolean advanceExact(int target) throws IOException {
+        if (target >= maxDoc) {
+            doc = NO_MORE_DOCS;
+            count = 0;
+            cursor = 0;
+            return false;
+        }
+        doc = target;
+        count = table.countForRow(target);
+        cursor = 0;
+        return count > 0;
+    }
+
+    @Override
+    public long nextOrd() {
+        return table.ordForRow(doc, cursor++);
+    }
+
+    @Override
+    public int docValueCount() {
+        return count;
+    }
+
+    @Override
+    public BytesRef lookupOrd(long ord) {
+        return table.lookupOrd((int) ord);
+    }
+
+    @Override
+    public long getValueCount() {
+        return table.valueCount();
+    }
+
+    @Override
+    public int docID() {
+        return doc;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+        return advance(doc + 1);
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+        for (int d = target; d < maxDoc; d++) {
+            if (table.countForRow(d) > 0) {
+                doc = d;
+                count = table.countForRow(d);
+                cursor = 0;
+                return d;
+            }
+        }
+        doc = NO_MORE_DOCS;
+        count = 0;
+        cursor = 0;
+        return NO_MORE_DOCS;
+    }
+
+    @Override
+    public long cost() {
+        return maxDoc;
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/package-info.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/iter/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Cache-aware Lucene DocValues iterators backed by Parquet columns: numeric, sorted-numeric,
+ * binary, sorted, and sorted-set. Each consults the column reader's page cache for hot-path
+ * reads and crosses the FFM boundary only on a page miss.
+ */
+package org.opensearch.parquet.codec.iter;

--- a/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/package-info.java
+++ b/sandbox/plugins/parquet-data-format/src/main/java/org/opensearch/parquet/codec/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Read-only Lucene {@code DocValuesFormat} codec that materializes per-document values from
+ * Parquet files through the standard {@code DocValuesProducer} API, for flat indices
+ * (Row ID = Doc ID).
+ *
+ * <p>This package and its subpackages hold the codec implementation: the physical-type
+ * mapping ({@link org.opensearch.parquet.codec.ParquetPhysicalType}), the layered cache
+ * structures ({@code org.opensearch.parquet.codec.cache}), and (in later tasks) the
+ * DocValues iterators, ordinal table, producer, and format.
+ */
+package org.opensearch.parquet.codec;

--- a/sandbox/plugins/parquet-data-format/src/main/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
+++ b/sandbox/plugins/parquet-data-format/src/main/resources/META-INF/services/org.apache.lucene.codecs.DocValuesFormat
@@ -1,0 +1,1 @@
+org.opensearch.parquet.codec.ParquetDocValuesFormat

--- a/sandbox/plugins/parquet-data-format/src/main/rust/Cargo.toml
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/Cargo.toml
@@ -24,6 +24,7 @@ rayon = { workspace = true }
 tokio = { workspace = true }
 crc32fast = { workspace = true }
 serde_json = { workspace = true }
+liquid-cache = { workspace = true }
 
 [dev-dependencies]
 opensearch-parquet-format = { path = ".", features = ["test-utils"] }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -15,14 +15,14 @@ use std::collections::HashMap;
 use std::slice;
 use std::str;
 use std::sync::atomic::{AtomicI64, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use lazy_static::lazy_static;
 use native_bridge_common::{ffm_safe, log_debug};
 
-use crate::native_settings::NativeSettings;
 use crate::field_config::FieldConfig;
 use crate::merge;
+use crate::native_settings::NativeSettings;
 use crate::writer::{NativeParquetWriter, SETTINGS_STORE};
 
 unsafe fn str_from_raw<'a>(ptr: *const u8, len: i64) -> Result<&'a str, String> {
@@ -59,10 +59,7 @@ unsafe fn str_array_from_raw(
 }
 
 /// Decode a parallel (pointers, count) array of i64 values interpreted as booleans (0 = false).
-unsafe fn bool_array_from_raw(
-    vals: *const i64,
-    count: i64,
-) -> Vec<bool> {
+unsafe fn bool_array_from_raw(vals: *const i64, count: i64) -> Vec<bool> {
     if count == 0 || vals.is_null() {
         return vec![];
     }
@@ -92,17 +89,27 @@ pub unsafe extern "C" fn parquet_create_writer(
     writer_generation: i64,
 ) -> i64 {
     let filename = str_from_raw(file_ptr, file_len)
-        .map_err(|e| format!("parquet_create_writer file: {}", e))?.to_string();
+        .map_err(|e| format!("parquet_create_writer file: {}", e))?
+        .to_string();
     let index_name = str_from_raw(index_name_ptr, index_name_len)
-        .map_err(|e| format!("parquet_create_writer index_name: {}", e))?.to_string();
+        .map_err(|e| format!("parquet_create_writer index_name: {}", e))?
+        .to_string();
     let sort_columns = str_array_from_raw(sort_ptrs, sort_lens, sort_count)
         .map_err(|e| format!("parquet_create_writer sort_columns: {}", e))?;
     let reverse_sorts = bool_array_from_raw(reverse_vals, reverse_count);
     let nulls_first = bool_array_from_raw(nulls_first_vals, nulls_first_count);
 
-    NativeParquetWriter::create_writer(filename, index_name, schema_address, sort_columns, reverse_sorts, nulls_first, writer_generation)
-        .map(|_| 0)
-        .map_err(|e| e.to_string())
+    NativeParquetWriter::create_writer(
+        filename,
+        index_name,
+        schema_address,
+        sort_columns,
+        reverse_sorts,
+        nulls_first,
+        writer_generation,
+    )
+    .map(|_| 0)
+    .map_err(|e| e.to_string())
 }
 
 #[ffm_safe]
@@ -113,7 +120,9 @@ pub unsafe extern "C" fn parquet_write(
     array_address: i64,
     schema_address: i64,
 ) -> i64 {
-    let filename = str_from_raw(file_ptr, file_len).map_err(|e| format!("parquet_write: {}", e))?.to_string();
+    let filename = str_from_raw(file_ptr, file_len)
+        .map_err(|e| format!("parquet_write: {}", e))?
+        .to_string();
     NativeParquetWriter::write_data(filename, array_address, schema_address)
         .map(|_| 0)
         .map_err(|e| e.to_string())
@@ -135,24 +144,36 @@ pub unsafe extern "C" fn parquet_finalize_writer(
     sort_perm_ptr_out: *mut i64,
     sort_perm_len_out: *mut i64,
 ) -> i64 {
-    let filename = str_from_raw(file_ptr, file_len).map_err(|e| format!("parquet_finalize_writer: {}", e))?.to_string();
+    let filename = str_from_raw(file_ptr, file_len)
+        .map_err(|e| format!("parquet_finalize_writer: {}", e))?
+        .to_string();
     match NativeParquetWriter::finalize_writer(filename) {
         Ok(Some(result)) => {
             let fm = result.metadata.file_metadata();
-            if !version_out.is_null() { *version_out = fm.version(); }
-            if !num_rows_out.is_null() { *num_rows_out = fm.num_rows(); }
+            if !version_out.is_null() {
+                *version_out = fm.version();
+            }
+            if !num_rows_out.is_null() {
+                *num_rows_out = fm.num_rows();
+            }
             if let Some(cb) = fm.created_by() {
                 if !created_by_buf.is_null() && created_by_buf_len > 0 {
                     let bytes = cb.as_bytes();
                     let n = bytes.len().min(created_by_buf_len as usize);
                     std::ptr::copy_nonoverlapping(bytes.as_ptr(), created_by_buf, n);
-                    if !created_by_len_out.is_null() { *created_by_len_out = n as i64; }
+                    if !created_by_len_out.is_null() {
+                        *created_by_len_out = n as i64;
+                    }
                 }
             } else if !created_by_len_out.is_null() {
                 *created_by_len_out = -1;
             }
-            if !crc32_out.is_null() { *crc32_out = result.crc32 as i64; }
-            if !num_row_groups_out.is_null() { *num_row_groups_out = result.metadata.num_row_groups() as i64; }
+            if !crc32_out.is_null() {
+                *crc32_out = result.crc32 as i64;
+            }
+            if !num_row_groups_out.is_null() {
+                *num_row_groups_out = result.metadata.num_row_groups() as i64;
+            }
 
             // Return sort permutation if present
             if !sort_perm_ptr_out.is_null() && !sort_perm_len_out.is_null() {
@@ -176,7 +197,6 @@ pub unsafe extern "C" fn parquet_finalize_writer(
     }
 }
 
-
 #[ffm_safe]
 #[no_mangle]
 pub unsafe extern "C" fn parquet_get_file_metadata(
@@ -189,18 +209,28 @@ pub unsafe extern "C" fn parquet_get_file_metadata(
     created_by_len_out: *mut i64,
     num_row_groups_out: *mut i64,
 ) -> i64 {
-    let filename = str_from_raw(file_ptr, file_len).map_err(|e| format!("parquet_get_file_metadata: {}", e))?.to_string();
+    let filename = str_from_raw(file_ptr, file_len)
+        .map_err(|e| format!("parquet_get_file_metadata: {}", e))?
+        .to_string();
     let metadata = NativeParquetWriter::get_file_metadata(filename).map_err(|e| e.to_string())?;
     let fm = metadata.file_metadata();
-    if !version_out.is_null() { *version_out = fm.version(); }
-    if !num_rows_out.is_null() { *num_rows_out = fm.num_rows(); }
-    if !num_row_groups_out.is_null() { *num_row_groups_out = metadata.num_row_groups() as i64; }
+    if !version_out.is_null() {
+        *version_out = fm.version();
+    }
+    if !num_rows_out.is_null() {
+        *num_rows_out = fm.num_rows();
+    }
+    if !num_row_groups_out.is_null() {
+        *num_row_groups_out = metadata.num_row_groups() as i64;
+    }
     if let Some(cb) = fm.created_by() {
         if !created_by_buf.is_null() && created_by_buf_len > 0 {
             let bytes = cb.as_bytes();
             let n = bytes.len().min(created_by_buf_len as usize);
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), created_by_buf, n);
-            if !created_by_len_out.is_null() { *created_by_len_out = n as i64; }
+            if !created_by_len_out.is_null() {
+                *created_by_len_out = n as i64;
+            }
         }
     } else if !created_by_len_out.is_null() {
         *created_by_len_out = -1;
@@ -223,9 +253,12 @@ pub unsafe extern "C" fn parquet_get_column_metadata(
     use parquet::file::reader::{FileReader, SerializedFileReader};
     use std::fs::File;
 
-    let filename = str_from_raw(file_ptr, file_len).map_err(|e| format!("parquet_get_column_metadata: {}", e))?.to_string();
+    let filename = str_from_raw(file_ptr, file_len)
+        .map_err(|e| format!("parquet_get_column_metadata: {}", e))?
+        .to_string();
     let file = File::open(&filename).map_err(|e| format!("Failed to open file: {}", e))?;
-    let reader = SerializedFileReader::new(file).map_err(|e| format!("Failed to read parquet: {}", e))?;
+    let reader =
+        SerializedFileReader::new(file).map_err(|e| format!("Failed to read parquet: {}", e))?;
     let metadata = reader.metadata();
 
     if metadata.num_row_groups() == 0 {
@@ -233,7 +266,9 @@ pub unsafe extern "C" fn parquet_get_column_metadata(
         let bytes = json.as_bytes();
         let n = bytes.len().min(out_buf_len as usize);
         std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf, n);
-        if !out_len.is_null() { *out_len = n as i64; }
+        if !out_len.is_null() {
+            *out_len = n as i64;
+        }
         return Ok(0);
     }
 
@@ -245,11 +280,17 @@ pub unsafe extern "C" fn parquet_get_column_metadata(
         let encodings: Vec<String> = col.encodings().map(|e| format!("{:?}", e)).collect();
         let compression = format!("{:?}", col.compression());
         let has_bloom_filter = col.bloom_filter_offset().is_some();
-        if i > 0 { json.push(','); }
+        if i > 0 {
+            json.push(',');
+        }
         json.push_str(&format!(
             "\"{}\":{{\"encodings\":[{}],\"compression\":\"{}\",\"bloom_filter\":{}}}",
             col_name,
-            encodings.iter().map(|e| format!("\"{}\"" , e)).collect::<Vec<_>>().join(","),
+            encodings
+                .iter()
+                .map(|e| format!("\"{}\"", e))
+                .collect::<Vec<_>>()
+                .join(","),
             compression,
             has_bloom_filter
         ));
@@ -259,7 +300,9 @@ pub unsafe extern "C" fn parquet_get_column_metadata(
     let bytes = json.as_bytes();
     let n = bytes.len().min(out_buf_len as usize);
     std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf, n);
-    if !out_len.is_null() { *out_len = n as i64; }
+    if !out_len.is_null() {
+        *out_len = n as i64;
+    }
     Ok(0)
 }
 
@@ -268,7 +311,9 @@ pub unsafe extern "C" fn parquet_get_filtered_native_bytes_used(
     prefix_ptr: *const u8,
     prefix_len: i64,
 ) -> i64 {
-    let prefix = str_from_raw(prefix_ptr, prefix_len).unwrap_or("").to_string();
+    let prefix = str_from_raw(prefix_ptr, prefix_len)
+        .unwrap_or("")
+        .to_string();
     NativeParquetWriter::get_filtered_writer_memory_usage(prefix).unwrap_or(0) as i64
 }
 
@@ -335,93 +380,218 @@ pub unsafe extern "C" fn parquet_on_settings_update(
     type_bf_ndv_count: i64,
 ) -> i64 {
     let index_name = str_from_raw(index_name_ptr, index_name_len)
-        .map_err(|e| format!("parquet_on_settings_update index_name: {}", e))?.to_string();
+        .map_err(|e| format!("parquet_on_settings_update index_name: {}", e))?
+        .to_string();
 
     let compression_type = if compression_type_ptr.is_null() || compression_type_len < 0 {
         None
     } else {
-        Some(str_from_raw(compression_type_ptr, compression_type_len)
-            .map_err(|e| format!("parquet_on_settings_update compression_type: {}", e))?.to_string())
+        Some(
+            str_from_raw(compression_type_ptr, compression_type_len)
+                .map_err(|e| format!("parquet_on_settings_update compression_type: {}", e))?
+                .to_string(),
+        )
     };
 
-    fn opt_i32(v: i64) -> Option<i32> { if v < 0 { None } else { Some(v as i32) } }
-    fn opt_usize(v: i64) -> Option<usize> { if v < 0 { None } else { Some(v as usize) } }
-    fn opt_bool(v: i64) -> Option<bool> { if v < 0 { None } else { Some(v != 0) } }
-    fn opt_f64(v: f64) -> Option<f64> { if v < 0.0 { None } else { Some(v) } }
-    fn opt_u64(v: i64) -> Option<u64> { if v < 0 { None } else { Some(v as u64) } }
+    fn opt_i32(v: i64) -> Option<i32> {
+        if v < 0 {
+            None
+        } else {
+            Some(v as i32)
+        }
+    }
+    fn opt_usize(v: i64) -> Option<usize> {
+        if v < 0 {
+            None
+        } else {
+            Some(v as usize)
+        }
+    }
+    fn opt_bool(v: i64) -> Option<bool> {
+        if v < 0 {
+            None
+        } else {
+            Some(v != 0)
+        }
+    }
+    fn opt_f64(v: f64) -> Option<f64> {
+        if v < 0.0 {
+            None
+        } else {
+            Some(v)
+        }
+    }
+    fn opt_u64(v: i64) -> Option<u64> {
+        if v < 0 {
+            None
+        } else {
+            Some(v as u64)
+        }
+    }
 
     let field_names = str_array_from_raw(field_name_ptrs, field_name_lens, field_count)
         .map_err(|e| format!("parquet_on_settings_update field_names: {}", e))?;
     let field_encodings = str_array_from_raw(field_encoding_ptrs, field_encoding_lens, field_count)
         .map_err(|e| format!("parquet_on_settings_update field_encodings: {}", e))?;
-    let field_compression_names = str_array_from_raw(field_compression_name_ptrs, field_compression_name_lens, field_compression_count)
-        .map_err(|e| format!("parquet_on_settings_update field_compression_names: {}", e))?;
-    let field_compressions = str_array_from_raw(field_compression_value_ptrs, field_compression_value_lens, field_compression_count)
-        .map_err(|e| format!("parquet_on_settings_update field_compressions: {}", e))?;
+    let field_compression_names = str_array_from_raw(
+        field_compression_name_ptrs,
+        field_compression_name_lens,
+        field_compression_count,
+    )
+    .map_err(|e| format!("parquet_on_settings_update field_compression_names: {}", e))?;
+    let field_compressions = str_array_from_raw(
+        field_compression_value_ptrs,
+        field_compression_value_lens,
+        field_compression_count,
+    )
+    .map_err(|e| format!("parquet_on_settings_update field_compressions: {}", e))?;
 
-    let type_encoding_names = str_array_from_raw(type_encoding_name_ptrs, type_encoding_name_lens, type_encoding_count)
-        .map_err(|e| format!("parquet_on_settings_update type_encoding_names: {}", e))?;
-    let type_encodings = str_array_from_raw(type_encoding_value_ptrs, type_encoding_value_lens, type_encoding_count)
-        .map_err(|e| format!("parquet_on_settings_update type_encodings: {}", e))?;
-    let type_compression_names = str_array_from_raw(type_compression_name_ptrs, type_compression_name_lens, type_compression_count)
-        .map_err(|e| format!("parquet_on_settings_update type_compression_names: {}", e))?;
-    let type_compressions = str_array_from_raw(type_compression_value_ptrs, type_compression_value_lens, type_compression_count)
-        .map_err(|e| format!("parquet_on_settings_update type_compressions: {}", e))?;
+    let type_encoding_names = str_array_from_raw(
+        type_encoding_name_ptrs,
+        type_encoding_name_lens,
+        type_encoding_count,
+    )
+    .map_err(|e| format!("parquet_on_settings_update type_encoding_names: {}", e))?;
+    let type_encodings = str_array_from_raw(
+        type_encoding_value_ptrs,
+        type_encoding_value_lens,
+        type_encoding_count,
+    )
+    .map_err(|e| format!("parquet_on_settings_update type_encodings: {}", e))?;
+    let type_compression_names = str_array_from_raw(
+        type_compression_name_ptrs,
+        type_compression_name_lens,
+        type_compression_count,
+    )
+    .map_err(|e| format!("parquet_on_settings_update type_compression_names: {}", e))?;
+    let type_compressions = str_array_from_raw(
+        type_compression_value_ptrs,
+        type_compression_value_lens,
+        type_compression_count,
+    )
+    .map_err(|e| format!("parquet_on_settings_update type_compressions: {}", e))?;
 
     // Parse per-field bloom filter arrays
-    let bf_enabled_names = str_array_from_raw(bf_enabled_name_ptrs, bf_enabled_name_lens, bf_enabled_count)
-        .map_err(|e| format!("parquet_on_settings_update bf_enabled_names: {}", e))?;
+    let bf_enabled_names =
+        str_array_from_raw(bf_enabled_name_ptrs, bf_enabled_name_lens, bf_enabled_count)
+            .map_err(|e| format!("parquet_on_settings_update bf_enabled_names: {}", e))?;
 
     let field_configs = {
         let mut map = std::collections::HashMap::new();
         for (name, encoding) in field_names.into_iter().zip(field_encodings.into_iter()) {
-            map.insert(name, FieldConfig { encoding_type: Some(encoding), ..Default::default() });
+            map.insert(
+                name,
+                FieldConfig {
+                    encoding_type: Some(encoding),
+                    ..Default::default()
+                },
+            );
         }
-        for (name, compression) in field_compression_names.into_iter().zip(field_compressions.into_iter()) {
+        for (name, compression) in field_compression_names
+            .into_iter()
+            .zip(field_compressions.into_iter())
+        {
             map.entry(name)
-               .and_modify(|fc| fc.compression_type = Some(compression.clone()))
-               .or_insert(FieldConfig { compression_type: Some(compression), ..Default::default() });
+                .and_modify(|fc| fc.compression_type = Some(compression.clone()))
+                .or_insert(FieldConfig {
+                    compression_type: Some(compression),
+                    ..Default::default()
+                });
         }
         for (i, name) in bf_enabled_names.into_iter().enumerate() {
             let val = *bf_enabled_vals.add(i) != 0;
             map.entry(name)
-               .and_modify(|fc| fc.bloom_filter_enabled = Some(val))
-               .or_insert(FieldConfig { bloom_filter_enabled: Some(val), ..Default::default() });
+                .and_modify(|fc| fc.bloom_filter_enabled = Some(val))
+                .or_insert(FieldConfig {
+                    bloom_filter_enabled: Some(val),
+                    ..Default::default()
+                });
         }
-        if map.is_empty() { None } else { Some(map) }
+        if map.is_empty() {
+            None
+        } else {
+            Some(map)
+        }
     };
 
     let type_encoding_configs: Option<std::collections::HashMap<String, String>> = {
-        let map: std::collections::HashMap<_, _> = type_encoding_names.into_iter().zip(type_encodings.into_iter()).collect();
-        if map.is_empty() { None } else { Some(map) }
+        let map: std::collections::HashMap<_, _> = type_encoding_names
+            .into_iter()
+            .zip(type_encodings.into_iter())
+            .collect();
+        if map.is_empty() {
+            None
+        } else {
+            Some(map)
+        }
     };
     let type_compression_configs: Option<std::collections::HashMap<String, String>> = {
-        let map: std::collections::HashMap<_, _> = type_compression_names.into_iter().zip(type_compressions.into_iter()).collect();
-        if map.is_empty() { None } else { Some(map) }
+        let map: std::collections::HashMap<_, _> = type_compression_names
+            .into_iter()
+            .zip(type_compressions.into_iter())
+            .collect();
+        if map.is_empty() {
+            None
+        } else {
+            Some(map)
+        }
     };
 
     // Parse type-level bloom filter arrays
-    let type_bf_enabled_names = str_array_from_raw(type_bf_enabled_name_ptrs, type_bf_enabled_name_lens, type_bf_enabled_count)
-        .map_err(|e| format!("parquet_on_settings_update type_bf_enabled_names: {}", e))?;
-    let type_bf_fpp_names = str_array_from_raw(type_bf_fpp_name_ptrs, type_bf_fpp_name_lens, type_bf_fpp_count)
-        .map_err(|e| format!("parquet_on_settings_update type_bf_fpp_names: {}", e))?;
-    let type_bf_ndv_names = str_array_from_raw(type_bf_ndv_name_ptrs, type_bf_ndv_name_lens, type_bf_ndv_count)
-        .map_err(|e| format!("parquet_on_settings_update type_bf_ndv_names: {}", e))?;
+    let type_bf_enabled_names = str_array_from_raw(
+        type_bf_enabled_name_ptrs,
+        type_bf_enabled_name_lens,
+        type_bf_enabled_count,
+    )
+    .map_err(|e| format!("parquet_on_settings_update type_bf_enabled_names: {}", e))?;
+    let type_bf_fpp_names = str_array_from_raw(
+        type_bf_fpp_name_ptrs,
+        type_bf_fpp_name_lens,
+        type_bf_fpp_count,
+    )
+    .map_err(|e| format!("parquet_on_settings_update type_bf_fpp_names: {}", e))?;
+    let type_bf_ndv_names = str_array_from_raw(
+        type_bf_ndv_name_ptrs,
+        type_bf_ndv_name_lens,
+        type_bf_ndv_count,
+    )
+    .map_err(|e| format!("parquet_on_settings_update type_bf_ndv_names: {}", e))?;
 
     let type_bloom_filter_enabled: Option<std::collections::HashMap<String, bool>> = {
-        let map: std::collections::HashMap<_, _> = type_bf_enabled_names.into_iter().enumerate()
-            .map(|(i, name)| (name, *type_bf_enabled_vals.add(i) != 0)).collect();
-        if map.is_empty() { None } else { Some(map) }
+        let map: std::collections::HashMap<_, _> = type_bf_enabled_names
+            .into_iter()
+            .enumerate()
+            .map(|(i, name)| (name, *type_bf_enabled_vals.add(i) != 0))
+            .collect();
+        if map.is_empty() {
+            None
+        } else {
+            Some(map)
+        }
     };
     let type_bloom_filter_fpp: Option<std::collections::HashMap<String, f64>> = {
-        let map: std::collections::HashMap<_, _> = type_bf_fpp_names.into_iter().enumerate()
-            .map(|(i, name)| (name, *type_bf_fpp_vals.add(i))).collect();
-        if map.is_empty() { None } else { Some(map) }
+        let map: std::collections::HashMap<_, _> = type_bf_fpp_names
+            .into_iter()
+            .enumerate()
+            .map(|(i, name)| (name, *type_bf_fpp_vals.add(i)))
+            .collect();
+        if map.is_empty() {
+            None
+        } else {
+            Some(map)
+        }
     };
     let type_bloom_filter_ndv: Option<std::collections::HashMap<String, u64>> = {
-        let map: std::collections::HashMap<_, _> = type_bf_ndv_names.into_iter().enumerate()
-            .map(|(i, name)| (name, *type_bf_ndv_vals.add(i) as u64)).collect();
-        if map.is_empty() { None } else { Some(map) }
+        let map: std::collections::HashMap<_, _> = type_bf_ndv_names
+            .into_iter()
+            .enumerate()
+            .map(|(i, name)| (name, *type_bf_ndv_vals.add(i) as u64))
+            .collect();
+        if map.is_empty() {
+            None
+        } else {
+            Some(map)
+        }
     };
 
     let config = NativeSettings {
@@ -460,7 +630,8 @@ pub unsafe extern "C" fn parquet_remove_settings(
     index_name_len: i64,
 ) -> i64 {
     let index_name = str_from_raw(index_name_ptr, index_name_len)
-        .map_err(|e| format!("parquet_remove_settings: {}", e))?.to_string();
+        .map_err(|e| format!("parquet_remove_settings: {}", e))?
+        .to_string();
     SETTINGS_STORE.remove(&index_name);
     Ok(0)
 }
@@ -524,7 +695,12 @@ pub unsafe extern "C" fn parquet_merge_files(
     };
 
     let result = if sort_cols.is_empty() {
-        merge::merge_unsorted(&input_files, output_path, index_name, output_writer_generation)
+        merge::merge_unsorted(
+            &input_files,
+            output_path,
+            index_name,
+            output_writer_generation,
+        )
     } else {
         merge::merge_sorted(
             &input_files,
@@ -540,19 +716,27 @@ pub unsafe extern "C" fn parquet_merge_files(
 
     // Write Parquet file metadata to out-pointers.
     let fm = result.metadata.file_metadata();
-    if !version_out.is_null() { *version_out = fm.version(); }
-    if !num_rows_out.is_null() { *num_rows_out = fm.num_rows(); }
+    if !version_out.is_null() {
+        *version_out = fm.version();
+    }
+    if !num_rows_out.is_null() {
+        *num_rows_out = fm.num_rows();
+    }
     if let Some(cb) = fm.created_by() {
         if !created_by_buf.is_null() && created_by_buf_len > 0 {
             let bytes = cb.as_bytes();
             let n = bytes.len().min(created_by_buf_len as usize);
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), created_by_buf, n);
-            if !created_by_len_out.is_null() { *created_by_len_out = n as i64; }
+            if !created_by_len_out.is_null() {
+                *created_by_len_out = n as i64;
+            }
         }
     } else if !created_by_len_out.is_null() {
         *created_by_len_out = -1;
     }
-    if !crc32_out.is_null() { *crc32_out = result.crc32 as i64; }
+    if !crc32_out.is_null() {
+        *crc32_out = result.crc32 as i64;
+    }
 
     // Write row-ID mapping into out-pointers as heap-allocated arrays.
     // Java reads them and then calls parquet_free_merge_result to deallocate.
@@ -594,7 +778,10 @@ pub unsafe extern "C" fn parquet_free_merge_result(
         let mapping_bytes = mapping_len as usize * std::mem::size_of::<i64>();
         // Java released merge mapping — free from pool
         crate::memory::merge_pool().shrink(mapping_bytes);
-        let _ = Box::from_raw(slice::from_raw_parts_mut(mapping_ptr as *mut i64, mapping_len as usize));
+        let _ = Box::from_raw(slice::from_raw_parts_mut(
+            mapping_ptr as *mut i64,
+            mapping_len as usize,
+        ));
     }
     let n = gen_count as usize;
     if gen_keys_ptr != 0 && n > 0 {
@@ -628,13 +815,16 @@ pub unsafe extern "C" fn parquet_read_as_json(
     use arrow::array::Array;
 
     let filename = str_from_raw(file_ptr, file_len)
-        .map_err(|e| format!("parquet_read_as_json: {}", e))?.to_string();
+        .map_err(|e| format!("parquet_read_as_json: {}", e))?
+        .to_string();
 
     let file = std::fs::File::open(&filename)
         .map_err(|e| format!("Failed to open {}: {}", filename, e))?;
     let builder = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
         .map_err(|e| format!("Failed to read parquet: {}", e))?;
-    let reader = builder.with_batch_size(8192).build()
+    let reader = builder
+        .with_batch_size(8192)
+        .build()
         .map_err(|e| format!("Failed to build reader: {}", e))?;
 
     let mut rows: Vec<serde_json::Value> = Vec::new();
@@ -650,26 +840,43 @@ pub unsafe extern "C" fn parquet_read_as_json(
                 } else {
                     match col.data_type() {
                         arrow::datatypes::DataType::Int32 => {
-                            let arr = col.as_any().downcast_ref::<arrow::array::Int32Array>().unwrap();
+                            let arr = col
+                                .as_any()
+                                .downcast_ref::<arrow::array::Int32Array>()
+                                .unwrap();
                             serde_json::Value::Number(arr.value(row_idx).into())
                         }
                         arrow::datatypes::DataType::Int64 => {
-                            let arr = col.as_any().downcast_ref::<arrow::array::Int64Array>().unwrap();
+                            let arr = col
+                                .as_any()
+                                .downcast_ref::<arrow::array::Int64Array>()
+                                .unwrap();
                             serde_json::Value::Number(arr.value(row_idx).into())
                         }
                         arrow::datatypes::DataType::Utf8 => {
-                            let arr = col.as_any().downcast_ref::<arrow::array::StringArray>().unwrap();
+                            let arr = col
+                                .as_any()
+                                .downcast_ref::<arrow::array::StringArray>()
+                                .unwrap();
                             serde_json::Value::String(arr.value(row_idx).to_string())
                         }
                         arrow::datatypes::DataType::Boolean => {
-                            let arr = col.as_any().downcast_ref::<arrow::array::BooleanArray>().unwrap();
+                            let arr = col
+                                .as_any()
+                                .downcast_ref::<arrow::array::BooleanArray>()
+                                .unwrap();
                             serde_json::Value::Bool(arr.value(row_idx))
                         }
                         arrow::datatypes::DataType::Float64 => {
-                            let arr = col.as_any().downcast_ref::<arrow::array::Float64Array>().unwrap();
+                            let arr = col
+                                .as_any()
+                                .downcast_ref::<arrow::array::Float64Array>()
+                                .unwrap();
                             serde_json::json!(arr.value(row_idx))
                         }
-                        _ => serde_json::Value::String(format!("<unsupported:{}>", col.data_type())),
+                        _ => {
+                            serde_json::Value::String(format!("<unsupported:{}>", col.data_type()))
+                        }
                     }
                 };
                 obj.insert(field.name().clone(), val);
@@ -678,11 +885,15 @@ pub unsafe extern "C" fn parquet_read_as_json(
         }
     }
 
-    let json_str = serde_json::to_string(&rows)
-        .map_err(|e| format!("JSON serialization failed: {}", e))?;
+    let json_str =
+        serde_json::to_string(&rows).map_err(|e| format!("JSON serialization failed: {}", e))?;
     let bytes = json_str.as_bytes();
     if bytes.len() > buf_capacity as usize {
-        return Err(format!("JSON output ({} bytes) exceeds buffer capacity ({})", bytes.len(), buf_capacity));
+        return Err(format!(
+            "JSON output ({} bytes) exceeds buffer capacity ({})",
+            bytes.len(),
+            buf_capacity
+        ));
     }
     std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf, bytes.len());
     *out_len = bytes.len() as i64;
@@ -695,15 +906,15 @@ pub unsafe extern "C" fn parquet_read_as_json(
 
 /// Frees the heap-allocated row ID mapping array returned as part of `parquet_finalize_writer`.
 #[no_mangle]
-pub unsafe extern "C" fn parquet_free_row_id_mapping(
-    mapping_ptr: i64,
-    mapping_len: i64,
-) {
+pub unsafe extern "C" fn parquet_free_row_id_mapping(mapping_ptr: i64, mapping_len: i64) {
     if mapping_ptr != 0 && mapping_len > 0 {
         let mapping_bytes = mapping_len as usize * std::mem::size_of::<i64>();
         // Java released write mapping — free from pool
         crate::memory::write_pool().shrink(mapping_bytes);
-        let _ = Box::from_raw(slice::from_raw_parts_mut(mapping_ptr as *mut i64, mapping_len as usize));
+        let _ = Box::from_raw(slice::from_raw_parts_mut(
+            mapping_ptr as *mut i64,
+            mapping_len as usize,
+        ));
     }
 }
 
@@ -719,10 +930,7 @@ pub unsafe extern "C" fn parquet_free_row_id_mapping(
 /// Returns 0 on success, negative error pointer on failure (per FFM convention).
 #[ffm_safe]
 #[no_mangle]
-pub unsafe extern "C" fn parquet_collect_runtime_metrics(
-    out_buf: *mut i64,
-    out_len: i64,
-) -> i64 {
+pub unsafe extern "C" fn parquet_collect_runtime_metrics(out_buf: *mut i64, out_len: i64) -> i64 {
     if out_buf.is_null() {
         return Err("parquet_collect_runtime_metrics: null out_buf".to_string());
     }
@@ -812,6 +1020,13 @@ pub unsafe extern "C" fn parquet_get_pool_stats(out_buf: *mut i64) {
 use std::fs::File;
 use std::sync::MutexGuard;
 
+use arrow::array::{Array, ArrayRef};
+use arrow::datatypes::DataType as ArrowDataType;
+use parquet::arrow::arrow_reader::{
+    ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReaderBuilder, RowSelection,
+    RowSelector,
+};
+use parquet::arrow::ProjectionMask;
 use parquet::basic::Type as PhysicalType;
 use parquet::column::reader::{ColumnReader, ColumnReaderImpl};
 use parquet::data_type::DataType as ParquetDataType;
@@ -838,17 +1053,28 @@ const TYPE_BYTE_ARRAY: i32 = 5;
 /// and the row-group layout needed to translate a global row position into a
 /// `(row_group, local_offset)` pair. Random access reopens the relevant row
 /// group per call — this is the documented *slow path*; the hot path goes
-/// through `parquet_decode_page_at_row` (page-resident caching on the Java side).
+/// through `parquet_decode_page_at_row` (page-resident caching on the Java side),
+/// which decodes via the arrow-rs record-batch reader built from the
+/// once-parsed `arrow_metadata` (no footer re-read per decode).
 struct ColumnReaderState {
+    /// Low-level reader kept for the slow paths (`parquet_read_value_at_row`,
+    /// `parquet_read_repeated_at_row`); the page-decode hot path uses
+    /// `arrow_metadata` + `file` instead.
     reader: SerializedFileReader<File>,
+    /// Parsed footer + arrow schema, constructed ONCE at `open()` (including the
+    /// page index) and reused for every `parquet_decode_page_at_row` via
+    /// `ParquetRecordBatchReaderBuilder::new_with_metadata` — cloning it is
+    /// cheap (`Arc`s all the way down).
+    arrow_metadata: ArrowReaderMetadata,
+    /// File handle for the arrow decode path; `try_clone()`d per decode (cheaper
+    /// than reopening by path).
+    file: File,
     /// Leaf column index within the Parquet schema descriptor.
     leaf_idx: usize,
     /// Physical type of the column (validated against the caller's expectation).
     physical_type: PhysicalType,
     /// True when the column has a repetition level > 0 (multi-valued).
     repeated: bool,
-    /// Max definition level of the column (0 = required; >0 = optional/nested).
-    max_def_level: i16,
     /// Total number of rows (records) in the file.
     row_count: i64,
     /// Global row index of the first row in each row group.
@@ -891,7 +1117,13 @@ struct PageEntry {
 
 impl ColumnReaderState {
     fn open(filename: &str, column: &str, expected_type: i32) -> Result<ColumnReaderState, String> {
-        let file = File::open(filename).map_err(|e| format!("Failed to open '{}': {}", filename, e))?;
+        let file =
+            File::open(filename).map_err(|e| format!("Failed to open '{}': {}", filename, e))?;
+        // Keep a second handle to the same file for the arrow decode path
+        // (the first is consumed by `SerializedFileReader`).
+        let arrow_file = file
+            .try_clone()
+            .map_err(|e| format!("Failed to clone file handle for '{}': {}", filename, e))?;
         // Load the Parquet page index (OffsetIndex + ColumnIndex) so we can build
         // the Layer 3/4 page layout. Falls back gracefully to row-group
         // granularity if the file was written without a page index.
@@ -901,20 +1133,32 @@ impl ColumnReaderState {
 
         // Extract everything we need from the (borrowed) metadata inside a block so
         // the borrow ends before we move `reader` into the returned struct.
-        let (leaf_idx, physical_type, repeated, max_def_level, row_count, rg_first_row, rg_num_rows, pages) = {
+        let (
+            leaf_idx,
+            physical_type,
+            repeated,
+            row_count,
+            rg_first_row,
+            rg_num_rows,
+            pages,
+            arrow_metadata,
+        ) = {
             let metadata = reader.metadata();
             let schema = metadata.file_metadata().schema_descr();
 
-            let mut found: Option<(usize, PhysicalType, i16, i16)> = None;
+            let mut found: Option<(usize, PhysicalType, i16)> = None;
             for i in 0..schema.num_columns() {
                 let descr = schema.column(i);
                 if descr.name() == column || descr.path().string() == column {
-                    found = Some((i, descr.physical_type(), descr.max_rep_level(), descr.max_def_level()));
+                    found = Some((i, descr.physical_type(), descr.max_rep_level()));
                     break;
                 }
             }
-            let (leaf_idx, phys, max_rep, max_def) = found.ok_or_else(|| {
-                format!("Column '{}' not found in parquet file '{}'", column, filename)
+            let (leaf_idx, phys, max_rep) = found.ok_or_else(|| {
+                format!(
+                    "Column '{}' not found in parquet file '{}'",
+                    column, filename
+                )
             })?;
 
             let actual = physical_type_code(phys);
@@ -939,17 +1183,41 @@ impl ColumnReaderState {
 
             let pages = build_page_layout(metadata, leaf_idx, phys, &rg_first_row, &rg_num_rows);
 
-            (leaf_idx, phys, max_rep > 0, max_def, row_count, rg_first_row, rg_num_rows, pages)
+            // Parse the footer into arrow-reader form ONCE. `try_new` reuses the
+            // already-parsed `ParquetMetaData` (page index included, loaded above),
+            // so per-decode builders never re-read the footer from disk.
+            let arrow_metadata = ArrowReaderMetadata::try_new(
+                std::sync::Arc::new(metadata.clone()),
+                ArrowReaderOptions::new(),
+            )
+            .map_err(|e| {
+                format!(
+                    "Failed to build arrow reader metadata for '{}': {}",
+                    filename, e
+                )
+            })?;
+
+            (
+                leaf_idx,
+                phys,
+                max_rep > 0,
+                row_count,
+                rg_first_row,
+                rg_num_rows,
+                pages,
+                arrow_metadata,
+            )
         };
 
         let liquid_file_id = crate::liquid_page_cache::file_id(filename);
 
         Ok(ColumnReaderState {
             reader,
+            arrow_metadata,
+            file: arrow_file,
             leaf_idx,
             physical_type,
             repeated,
-            max_def_level,
             row_count,
             rg_first_row,
             rg_num_rows,
@@ -967,7 +1235,10 @@ impl ColumnReaderState {
                 return Ok((i, row - start));
             }
         }
-        Err(format!("Row {} not found in any row group (row count {})", row, self.row_count))
+        Err(format!(
+            "Row {} not found in any row group (row count {})",
+            row, self.row_count
+        ))
     }
 
     /// Find the index of the page containing global row `row` (binary search over
@@ -977,14 +1248,20 @@ impl ColumnReaderState {
         // page we want is the one immediately before it.
         let p = self.pages.partition_point(|e| e.global_first_row <= row);
         if p == 0 {
-            return Err(format!("Row {} precedes the first page (row count {})", row, self.row_count));
+            return Err(format!(
+                "Row {} precedes the first page (row count {})",
+                row, self.row_count
+            ));
         }
         let idx = p - 1;
         let entry = &self.pages[idx];
         if row >= entry.global_first_row && row < entry.global_first_row + entry.num_rows {
             Ok(idx)
         } else {
-            Err(format!("Row {} not found in any page (row count {})", row, self.row_count))
+            Err(format!(
+                "Row {} not found in any page (row count {})",
+                row, self.row_count
+            ))
         }
     }
 }
@@ -1026,9 +1303,8 @@ fn build_page_layout(
                     };
                     let num_rows = next_local - local_first;
                     let null_count = ci.and_then(|c| c.null_count(p)).unwrap_or(-1);
-                    let (min_long, max_long) = ci
-                        .map(|c| page_min_max(c, p, phys))
-                        .unwrap_or((0, 0));
+                    let (min_long, max_long) =
+                        ci.map(|c| page_min_max(c, p, phys)).unwrap_or((0, 0));
                     pages.push(PageEntry {
                         global_first_row: rg_first_row[rg] + local_first,
                         num_rows,
@@ -1091,8 +1367,12 @@ fn page_min_max(ci: &ColumnIndexMetaData, idx: usize, _phys: PhysicalType) -> (i
             p.max_value(idx).map(|v| v.to_bits() as i64).unwrap_or(0),
         ),
         ColumnIndexMetaData::BOOLEAN(p) => (
-            p.min_value(idx).map(|v| if *v { 1 } else { 0 }).unwrap_or(0),
-            p.max_value(idx).map(|v| if *v { 1 } else { 0 }).unwrap_or(0),
+            p.min_value(idx)
+                .map(|v| if *v { 1 } else { 0 })
+                .unwrap_or(0),
+            p.max_value(idx)
+                .map(|v| if *v { 1 } else { 0 })
+                .unwrap_or(0),
         ),
         _ => (0, 0),
     }
@@ -1125,7 +1405,10 @@ fn read_record_values<T: ParquetDataType>(
     if skip > 0 {
         let skipped = r.skip_records(skip).map_err(|e| e.to_string())?;
         if skipped < skip {
-            return Err(format!("requested skip of {} records but only {} available", skip, skipped));
+            return Err(format!(
+                "requested skip of {} records but only {} available",
+                skip, skipped
+            ));
         }
     }
     let mut def_levels: Vec<i16> = Vec::new();
@@ -1138,21 +1421,50 @@ fn read_record_values<T: ParquetDataType>(
 
 lazy_static! {
     /// Per-handle registry of open column readers, keyed by an opaque i64 handle.
-    /// Mirrors the writer-side handle pattern; serialised behind a single mutex
-    /// since column readers are not shared across threads.
-    static ref COLUMN_READERS: Mutex<HashMap<i64, ColumnReaderState>> = Mutex::new(HashMap::new());
+    ///
+    /// Two-level locking: the outer mutex guards only the handle → state *map*
+    /// (insert/remove/lookup, all O(1) and IO-free); each `ColumnReaderState`
+    /// sits behind its own `Arc<Mutex<..>>`. Entry points lock the registry just
+    /// long enough to clone the state's `Arc`, then release it and lock the
+    /// individual state for the actual work — so decodes on different handles
+    /// (different columns/queries, or a future prefetch thread) run concurrently
+    /// instead of serialising process-wide. No entry point may hold the registry
+    /// lock across file IO or a page decode.
+    static ref COLUMN_READERS: Mutex<ColumnReaderRegistry> = Mutex::new(HashMap::new());
 }
+
+/// The outer registry map: handle → per-handle state cell.
+type ColumnReaderRegistry = HashMap<i64, Arc<Mutex<ColumnReaderState>>>;
 
 /// Monotonic handle allocator. Always `>= 0`, so a returned handle is never
 /// confused with the `< 0` error-pointer convention.
 static NEXT_COLUMN_READER_HANDLE: AtomicI64 = AtomicI64::new(0);
 
-/// Locks the column-reader registry, converting a poisoned mutex into a normal
-/// FFM error instead of propagating the panic.
-fn lock_readers<'a>() -> Result<MutexGuard<'a, HashMap<i64, ColumnReaderState>>, String> {
+/// Locks the column-reader registry (the outer map lock — hold only for handle
+/// lookup/insert/remove, never across IO or decode), converting a poisoned
+/// mutex into a normal FFM error instead of propagating the panic.
+fn lock_registry<'a>() -> Result<MutexGuard<'a, ColumnReaderRegistry>, String> {
     COLUMN_READERS
         .lock()
         .map_err(|_| "column reader registry mutex poisoned".to_string())
+}
+
+/// Resolves `handle` to its state cell, holding the registry lock only for the
+/// `Arc` clone. `ctx` names the calling entry point for the error message.
+fn state_for_handle(handle: i64, ctx: &str) -> Result<Arc<Mutex<ColumnReaderState>>, String> {
+    lock_registry()?
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| format!("{}: unknown handle {}", ctx, handle))
+}
+
+/// Locks one column reader's state for the duration of a call, converting a
+/// poisoned mutex into a normal FFM error.
+fn lock_state(
+    cell: &Arc<Mutex<ColumnReaderState>>,
+) -> Result<MutexGuard<'_, ColumnReaderState>, String> {
+    cell.lock()
+        .map_err(|_| "column reader state mutex poisoned".to_string())
 }
 
 /// Opens a per-column reader over `file` for `col`, validating that the column
@@ -1179,31 +1491,44 @@ pub unsafe extern "C" fn parquet_open_column_reader(
     let state = ColumnReaderState::open(&filename, &column, expected_type)?;
 
     let handle = NEXT_COLUMN_READER_HANDLE.fetch_add(1, Ordering::SeqCst);
-    lock_readers()?.insert(handle, state);
+    lock_registry()?.insert(handle, Arc::new(Mutex::new(state)));
     log_debug!(
         "parquet_open_column_reader: file={}, column={}, handle={}",
-        filename, column, handle
+        filename,
+        column,
+        handle
     );
     Ok(handle)
 }
 
 /// Closes a column reader handle and releases its file handle and buffers.
 /// Returns `0` on success, a `< 0` error pointer if the handle is unknown.
+///
+/// Close-vs-in-flight-decode semantics: this only removes the handle's `Arc`
+/// from the registry. If another thread is mid-decode on the same handle it
+/// still owns a clone of the `Arc`, so the state (and its file handle) stays
+/// alive until that decode finishes and drops the last clone — close never
+/// frees state out from under an in-flight call. New calls made after the
+/// remove fail with "unknown handle".
 #[ffm_safe]
 #[no_mangle]
 pub unsafe extern "C" fn parquet_close_column_reader(handle: i64) -> i64 {
-    match lock_readers()?.remove(&handle) {
+    match lock_registry()?.remove(&handle) {
         Some(_) => {
             log_debug!("parquet_close_column_reader: handle={}", handle);
             Ok(RC_OK)
         }
-        None => Err(format!("parquet_close_column_reader: unknown handle {}", handle)),
+        None => Err(format!(
+            "parquet_close_column_reader: unknown handle {}",
+            handle
+        )),
     }
 }
 
 /// Debug-only symbol: returns the number of currently open column-reader
-/// handles. Used by Property 7 (native handle non-leakage). Never errors;
-/// recovers from a poisoned mutex rather than panicking.
+/// handles (registry map size only; individual state locks are not taken).
+/// Used by Property 7 (native handle non-leakage). Never errors; recovers
+/// from a poisoned mutex rather than panicking.
 #[no_mangle]
 pub unsafe extern "C" fn parquet_open_column_reader_count() -> i64 {
     match COLUMN_READERS.lock() {
@@ -1218,7 +1543,11 @@ pub unsafe extern "C" fn parquet_open_column_reader_count() -> i64 {
 /// path is unchanged. A `max_memory_bytes` of 0 leaves the liquid-cache default budget.
 #[no_mangle]
 pub unsafe extern "C" fn parquet_liquid_cache_set_enabled(enabled: i32, max_memory_bytes: i64) {
-    let bytes = if max_memory_bytes > 0 { max_memory_bytes as usize } else { 0 };
+    let bytes = if max_memory_bytes > 0 {
+        max_memory_bytes as usize
+    } else {
+        0
+    };
     crate::liquid_page_cache::set_enabled(enabled != 0, bytes);
 }
 
@@ -1248,10 +1577,8 @@ pub unsafe extern "C" fn parquet_read_value_at_row(
     out_buf_cap: i64,
     out_len: *mut i64,
 ) -> i64 {
-    let mut guard = lock_readers()?;
-    let state = guard
-        .get_mut(&handle)
-        .ok_or_else(|| format!("parquet_read_value_at_row: unknown handle {}", handle))?;
+    let cell = state_for_handle(handle, "parquet_read_value_at_row")?;
+    let state = lock_state(&cell)?;
 
     if row < 0 {
         return Err(format!("parquet_read_value_at_row: negative row {}", row));
@@ -1275,8 +1602,13 @@ pub unsafe extern "C" fn parquet_read_value_at_row(
     }
 
     let (rg_idx, local) = state.locate(row)?;
-    let rg = state.reader.get_row_group(rg_idx).map_err(|e| e.to_string())?;
-    let col = rg.get_column_reader(state.leaf_idx).map_err(|e| e.to_string())?;
+    let rg = state
+        .reader
+        .get_row_group(rg_idx)
+        .map_err(|e| e.to_string())?;
+    let col = rg
+        .get_column_reader(state.leaf_idx)
+        .map_err(|e| e.to_string())?;
     let local = local as usize;
 
     match col {
@@ -1389,13 +1721,14 @@ pub unsafe extern "C" fn parquet_read_repeated_at_row(
     out_byte_offsets: *mut i64,
     out_byte_buf_cap: i64,
 ) -> i64 {
-    let mut guard = lock_readers()?;
-    let state = guard
-        .get_mut(&handle)
-        .ok_or_else(|| format!("parquet_read_repeated_at_row: unknown handle {}", handle))?;
+    let cell = state_for_handle(handle, "parquet_read_repeated_at_row")?;
+    let state = lock_state(&cell)?;
 
     if row < 0 {
-        return Err(format!("parquet_read_repeated_at_row: negative row {}", row));
+        return Err(format!(
+            "parquet_read_repeated_at_row: negative row {}",
+            row
+        ));
     }
     if row >= state.row_count {
         return Err(format!(
@@ -1409,40 +1742,89 @@ pub unsafe extern "C" fn parquet_read_repeated_at_row(
     }
 
     let (rg_idx, local) = state.locate(row)?;
-    let rg = state.reader.get_row_group(rg_idx).map_err(|e| e.to_string())?;
-    let col = rg.get_column_reader(state.leaf_idx).map_err(|e| e.to_string())?;
+    let rg = state
+        .reader
+        .get_row_group(rg_idx)
+        .map_err(|e| e.to_string())?;
+    let col = rg
+        .get_column_reader(state.leaf_idx)
+        .map_err(|e| e.to_string())?;
     let local = local as usize;
 
     match col {
         ColumnReader::Int32ColumnReader(mut r) => {
             let vals = read_record_values(&mut r, local)?;
-            write_primitive_repeated(vals.iter().map(|v| *v as i64), vals.len(), out_count, out_longs, out_long_cap)
+            write_primitive_repeated(
+                vals.iter().map(|v| *v as i64),
+                vals.len(),
+                out_count,
+                out_longs,
+                out_long_cap,
+            )
         }
         ColumnReader::Int64ColumnReader(mut r) => {
             let vals = read_record_values(&mut r, local)?;
-            write_primitive_repeated(vals.iter().copied(), vals.len(), out_count, out_longs, out_long_cap)
+            write_primitive_repeated(
+                vals.iter().copied(),
+                vals.len(),
+                out_count,
+                out_longs,
+                out_long_cap,
+            )
         }
         ColumnReader::FloatColumnReader(mut r) => {
             let vals = read_record_values(&mut r, local)?;
-            write_primitive_repeated(vals.iter().map(|v| v.to_bits() as i64), vals.len(), out_count, out_longs, out_long_cap)
+            write_primitive_repeated(
+                vals.iter().map(|v| v.to_bits() as i64),
+                vals.len(),
+                out_count,
+                out_longs,
+                out_long_cap,
+            )
         }
         ColumnReader::DoubleColumnReader(mut r) => {
             let vals = read_record_values(&mut r, local)?;
-            write_primitive_repeated(vals.iter().map(|v| v.to_bits() as i64), vals.len(), out_count, out_longs, out_long_cap)
+            write_primitive_repeated(
+                vals.iter().map(|v| v.to_bits() as i64),
+                vals.len(),
+                out_count,
+                out_longs,
+                out_long_cap,
+            )
         }
         ColumnReader::BoolColumnReader(mut r) => {
             let vals = read_record_values(&mut r, local)?;
-            write_primitive_repeated(vals.iter().map(|v| if *v { 1i64 } else { 0i64 }), vals.len(), out_count, out_longs, out_long_cap)
+            write_primitive_repeated(
+                vals.iter().map(|v| if *v { 1i64 } else { 0i64 }),
+                vals.len(),
+                out_count,
+                out_longs,
+                out_long_cap,
+            )
         }
         ColumnReader::ByteArrayColumnReader(mut r) => {
             let vals = read_record_values(&mut r, local)?;
             let slices: Vec<&[u8]> = vals.iter().map(|v| v.data()).collect();
-            write_bytes_repeated(&slices, out_count, out_long_cap, out_byte_buf, out_byte_offsets, out_byte_buf_cap)
+            write_bytes_repeated(
+                &slices,
+                out_count,
+                out_long_cap,
+                out_byte_buf,
+                out_byte_offsets,
+                out_byte_buf_cap,
+            )
         }
         ColumnReader::FixedLenByteArrayColumnReader(mut r) => {
             let vals = read_record_values(&mut r, local)?;
             let slices: Vec<&[u8]> = vals.iter().map(|v| v.data()).collect();
-            write_bytes_repeated(&slices, out_count, out_long_cap, out_byte_buf, out_byte_offsets, out_byte_buf_cap)
+            write_bytes_repeated(
+                &slices,
+                out_count,
+                out_long_cap,
+                out_byte_buf,
+                out_byte_offsets,
+                out_byte_buf_cap,
+            )
         }
         ColumnReader::Int96ColumnReader(_) => {
             Err("parquet_read_repeated_at_row: INT96 columns are not supported".to_string())
@@ -1534,10 +1916,8 @@ unsafe fn write_bytes_repeated(
 #[ffm_safe]
 #[no_mangle]
 pub unsafe extern "C" fn parquet_get_column_num_pages(handle: i64) -> i64 {
-    let guard = lock_readers()?;
-    let state = guard
-        .get(&handle)
-        .ok_or_else(|| format!("parquet_get_column_num_pages: unknown handle {}", handle))?;
+    let cell = state_for_handle(handle, "parquet_get_column_num_pages")?;
+    let state = lock_state(&cell)?;
     Ok(state.pages.len() as i64)
 }
 
@@ -1570,10 +1950,8 @@ pub unsafe extern "C" fn parquet_get_column_page_index(
     out_buf_capacity: i64,
     out_actual_pages: *mut i64,
 ) -> i64 {
-    let guard = lock_readers()?;
-    let state = guard
-        .get(&handle)
-        .ok_or_else(|| format!("parquet_get_column_page_index: unknown handle {}", handle))?;
+    let cell = state_for_handle(handle, "parquet_get_column_page_index")?;
+    let state = lock_state(&cell)?;
 
     let n = state.pages.len();
     if !out_actual_pages.is_null() {
@@ -1606,49 +1984,6 @@ pub unsafe extern "C" fn parquet_get_column_page_index(
     Ok(RC_OK)
 }
 
-/// Decodes one page's worth of single-valued records, returning a per-row
-/// presence flag (`true` = value present) and the dense list of non-null values
-/// in row order. `skip` records are skipped first, then `num_rows` records are
-/// read. Works for required columns (`max_def_level == 0`, all present) and
-/// optional non-repeated columns.
-fn decode_page_records<T: ParquetDataType>(
-    r: &mut ColumnReaderImpl<T>,
-    skip: usize,
-    num_rows: usize,
-    max_def_level: i16,
-) -> Result<(Vec<bool>, Vec<T::T>), String> {
-    if skip > 0 {
-        let skipped = r.skip_records(skip).map_err(|e| e.to_string())?;
-        if skipped < skip {
-            return Err(format!(
-                "page decode: requested skip of {} records but only {} available",
-                skip, skipped
-            ));
-        }
-    }
-
-    let mut def_levels: Vec<i16> = Vec::with_capacity(num_rows);
-    let mut values: Vec<T::T> = Vec::with_capacity(num_rows);
-    let (records_read, _values_read, _levels_read) = r
-        .read_records(num_rows, Some(&mut def_levels), None, &mut values)
-        .map_err(|e| e.to_string())?;
-    if records_read < num_rows {
-        return Err(format!(
-            "page decode: expected {} records but read {}",
-            num_rows, records_read
-        ));
-    }
-
-    // Build the per-row presence vector. For required columns `read_records`
-    // ignores the def-level buffer and every row is present.
-    let presence = if max_def_level == 0 {
-        vec![true; num_rows]
-    } else {
-        def_levels.iter().take(num_rows).map(|d| *d == max_def_level).collect()
-    };
-    Ok((presence, values))
-}
-
 /// Packs a per-row presence slice into a little-endian `long[]` bitset (bit i set
 /// when row i is present), writing into `out` (capacity `out_words`). Returns the
 /// number of words required; on capacity shortfall writes nothing and the caller
@@ -1676,6 +2011,12 @@ unsafe fn write_presence_bitset(presence: &[bool], out: *mut i64, out_words: i64
 }
 
 /// Layer 1 + 2: decode the page containing global row `row` into caller buffers.
+///
+/// Decode goes through the arrow-rs record-batch reader: a trivial
+/// `RowSelection` of `[skip(local_first), select(page_rows), skip(rest of RG)]`
+/// over the page's single row group, projected to the one leaf column. The
+/// builder is constructed from the `ArrowReaderMetadata` parsed once at
+/// `open()` (`new_with_metadata`), so no footer bytes are re-read per decode.
 ///
 /// On success (`RC_OK`):
 ///   - `out_first_row` / `out_last_row` = inclusive global row range of the page
@@ -1707,10 +2048,8 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
     out_presence_bitset: *mut i64,
     out_presence_bits_cap: i64,
 ) -> i64 {
-    let mut guard = lock_readers()?;
-    let state = guard
-        .get_mut(&handle)
-        .ok_or_else(|| format!("parquet_decode_page_at_row: unknown handle {}", handle))?;
+    let cell = state_for_handle(handle, "parquet_decode_page_at_row")?;
+    let state = lock_state(&cell)?;
 
     if row < 0 || row >= state.row_count {
         return Err(format!(
@@ -1726,14 +2065,11 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
     }
 
     let page_idx = state.page_for_row(row)?;
-    // Copy out the page's coordinates before borrowing the reader mutably.
     let (rg_idx, local_first, num_rows, first_global) = {
         let e = &state.pages[page_idx];
         (e.rg_idx, e.local_first_row, e.num_rows, e.global_first_row)
     };
     let num_rows_usize = num_rows as usize;
-    let max_def_level = state.max_def_level;
-    let physical_type = state.physical_type;
 
     // Always report the page row range so the caller can bound its cache and
     // size buffers even on the overflow path.
@@ -1746,7 +2082,7 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
 
     // Cross-query decoded-page cache (codec-owned liquid instance). When enabled, a hit serves the
     // decoded page from the node-level cache and skips the Parquet decode below entirely; a miss
-    // decodes as usual and backfills the cache (see the primitive arms). Keyed by
+    // decodes as usual and backfills the cache (see the primitive arm below). Keyed by
     // (file, column, page); primitives only. No-op when the feature flag is off.
     let lc_eid = if crate::liquid_page_cache::enabled() {
         Some(crate::liquid_page_cache::entry_id(
@@ -1760,146 +2096,310 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
     if let Some(eid) = lc_eid {
         if let Some((longs, presence)) = crate::liquid_page_cache::get_page(eid) {
             return write_primitive_page(
-                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
-                out_presence_bitset, out_presence_bits_cap,
+                &longs,
+                &presence,
+                out_value_buf,
+                out_value_buf_cap,
+                out_value_actual_len,
+                out_presence_bitset,
+                out_presence_bits_cap,
             );
         }
     }
 
-    let rg = state.reader.get_row_group(rg_idx).map_err(|e| e.to_string())?;
-    let col = rg.get_column_reader(state.leaf_idx).map_err(|e| e.to_string())?;
-    let skip = local_first as usize;
+    // Liquid miss: decode the whole page via the arrow record-batch reader.
+    let array = decode_page_arrow(&state, rg_idx, local_first, num_rows_usize)?;
 
-    // Decode the page into per-row presence + raw-bit values (primitives) or a
-    // backing byte buffer + CSR offsets (BYTE_ARRAY), then validate caller
-    // capacities and either copy out or signal overflow.
-    match col {
-        ColumnReader::Int32ColumnReader(mut r) => {
-            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
-            let longs = expand_primitive(&presence, &values, |v| v as i64);
+    match state.physical_type {
+        PhysicalType::BOOLEAN
+        | PhysicalType::INT32
+        | PhysicalType::INT64
+        | PhysicalType::FLOAT
+        | PhysicalType::DOUBLE => {
+            let (longs, presence) = arrow_primitive_to_page(&array)?;
             if let Some(eid) = lc_eid {
                 crate::liquid_page_cache::put_page(eid, &longs, &presence);
             }
-            return write_primitive_page(
-                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
-                out_presence_bitset, out_presence_bits_cap,
-            );
+            write_primitive_page(
+                &longs,
+                &presence,
+                out_value_buf,
+                out_value_buf_cap,
+                out_value_actual_len,
+                out_presence_bitset,
+                out_presence_bits_cap,
+            )
         }
-        ColumnReader::Int64ColumnReader(mut r) => {
-            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
-            let longs = expand_primitive(&presence, &values, |v| v);
-            if let Some(eid) = lc_eid {
-                crate::liquid_page_cache::put_page(eid, &longs, &presence);
-            }
-            return write_primitive_page(
-                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
-                out_presence_bitset, out_presence_bits_cap,
-            );
+        PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY => {
+            let (slices, presence) = arrow_bytes_to_page(&array)?;
+            write_bytes_page(
+                &slices,
+                &presence,
+                out_value_buf,
+                out_value_buf_cap,
+                out_value_actual_len,
+                out_byte_offsets,
+                out_byte_offsets_cap,
+                out_presence_bitset,
+                out_presence_bits_cap,
+            )
         }
-        ColumnReader::FloatColumnReader(mut r) => {
-            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
-            let longs = expand_primitive(&presence, &values, |v| v.to_bits() as i64);
-            if let Some(eid) = lc_eid {
-                crate::liquid_page_cache::put_page(eid, &longs, &presence);
-            }
-            return write_primitive_page(
-                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
-                out_presence_bitset, out_presence_bits_cap,
-            );
-        }
-        ColumnReader::DoubleColumnReader(mut r) => {
-            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
-            let longs = expand_primitive(&presence, &values, |v| v.to_bits() as i64);
-            if let Some(eid) = lc_eid {
-                crate::liquid_page_cache::put_page(eid, &longs, &presence);
-            }
-            return write_primitive_page(
-                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
-                out_presence_bitset, out_presence_bits_cap,
-            );
-        }
-        ColumnReader::BoolColumnReader(mut r) => {
-            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
-            let longs = expand_primitive(&presence, &values, |v| if v { 1i64 } else { 0i64 });
-            if let Some(eid) = lc_eid {
-                crate::liquid_page_cache::put_page(eid, &longs, &presence);
-            }
-            return write_primitive_page(
-                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
-                out_presence_bitset, out_presence_bits_cap,
-            );
-        }
-        ColumnReader::ByteArrayColumnReader(mut r) => {
-            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
-            let slices = expand_bytes(&presence, &values);
-            return write_bytes_page(
-                &slices, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
-                out_byte_offsets, out_byte_offsets_cap, out_presence_bitset, out_presence_bits_cap,
-            );
-        }
-        ColumnReader::FixedLenByteArrayColumnReader(mut r) => {
-            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
-            let slices = expand_flba(&presence, &values);
-            return write_bytes_page(
-                &slices, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
-                out_byte_offsets, out_byte_offsets_cap, out_presence_bitset, out_presence_bits_cap,
-            );
-        }
-        ColumnReader::Int96ColumnReader(_) => {
-            let _ = physical_type; // silence unused in this arm
+        PhysicalType::INT96 => {
             Err("parquet_decode_page_at_row: INT96 columns are not supported".to_string())
         }
     }
 }
 
-/// Expands dense non-null primitive values into a per-row `i64` slot vector
-/// (null rows hold 0), applying `to_bits` to each present value.
-fn expand_primitive<T: Copy>(presence: &[bool], dense: &[T], to_bits: impl Fn(T) -> i64) -> Vec<i64> {
-    let mut out = Vec::with_capacity(presence.len());
-    let mut di = 0usize;
-    for &present in presence {
-        if present {
-            out.push(to_bits(dense[di]));
-            di += 1;
-        } else {
-            out.push(0);
-        }
+/// Decodes one whole page (`num_rows` records starting `local_first` into row
+/// group `rg_idx`) of the state's leaf column into a single arrow array.
+///
+/// Selection shape: `[skip(local_first), select(num_rows), skip(rest of RG)]`
+/// over just `rg_idx`; batch size = page rows so the reader usually yields one
+/// batch (multiple batches are concatenated). The builder reuses the state's
+/// once-parsed `ArrowReaderMetadata` and a `try_clone()` of its file handle —
+/// no footer re-read, no path re-open.
+///
+/// Dictionary-encoded columns: the writer does not embed a `Dictionary` arrow
+/// type hint, so parquet-rs hydrates dictionary pages to plain arrays. As a
+/// belt-and-braces guard the result is cast to the dictionary's value type if
+/// a `DictionaryArray` ever surfaces, keeping the conversion helpers simple.
+fn decode_page_arrow(
+    state: &ColumnReaderState,
+    rg_idx: usize,
+    local_first: i64,
+    num_rows: usize,
+) -> Result<ArrayRef, String> {
+    let rg_rows = state.rg_num_rows[rg_idx];
+    let trailing = rg_rows - local_first - num_rows as i64;
+    let mut selectors = Vec::with_capacity(3);
+    if local_first > 0 {
+        selectors.push(RowSelector::skip(local_first as usize));
     }
-    out
+    selectors.push(RowSelector::select(num_rows));
+    if trailing > 0 {
+        selectors.push(RowSelector::skip(trailing as usize));
+    }
+
+    let file = state
+        .file
+        .try_clone()
+        .map_err(|e| format!("page decode: failed to clone file handle: {}", e))?;
+    let mask = ProjectionMask::leaves(state.arrow_metadata.parquet_schema(), [state.leaf_idx]);
+    let reader =
+        ParquetRecordBatchReaderBuilder::new_with_metadata(file, state.arrow_metadata.clone())
+            .with_row_groups(vec![rg_idx])
+            .with_projection(mask)
+            .with_batch_size(num_rows)
+            .with_row_selection(RowSelection::from(selectors))
+            .build()
+            .map_err(|e| format!("page decode: failed to build arrow reader: {}", e))?;
+
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(1);
+    for batch in reader {
+        let batch = batch.map_err(|e| format!("page decode: batch read failed: {}", e))?;
+        if batch.num_columns() != 1 {
+            return Err(format!(
+                "page decode: expected 1 projected column, got {}",
+                batch.num_columns()
+            ));
+        }
+        arrays.push(batch.column(0).clone());
+    }
+    let array = match arrays.len() {
+        0 => return Err("page decode: reader returned no batches".to_string()),
+        1 => arrays.pop().expect("len checked"),
+        _ => {
+            let refs: Vec<&dyn Array> = arrays.iter().map(|a| a.as_ref()).collect();
+            arrow::compute::concat(&refs)
+                .map_err(|e| format!("page decode: failed to concat batches: {}", e))?
+        }
+    };
+    if array.len() != num_rows {
+        return Err(format!(
+            "page decode: expected {} rows but decoded {}",
+            num_rows,
+            array.len()
+        ));
+    }
+    // Hydrate a DictionaryArray to its value type (see doc comment).
+    if let ArrowDataType::Dictionary(_, value_type) = array.data_type() {
+        let value_type = value_type.as_ref().clone();
+        return arrow::compute::cast(&array, &value_type)
+            .map_err(|e| format!("page decode: failed to hydrate dictionary column: {}", e));
+    }
+    Ok(array)
 }
 
-/// Expands dense non-null BYTE_ARRAY values into a per-row slice vector (null
-/// rows map to an empty slice).
-fn expand_bytes<'a>(presence: &[bool], dense: &'a [parquet::data_type::ByteArray]) -> Vec<&'a [u8]> {
-    let mut out: Vec<&[u8]> = Vec::with_capacity(presence.len());
-    let mut di = 0usize;
-    for &present in presence {
-        if present {
-            out.push(dense[di].data());
-            di += 1;
-        } else {
-            out.push(&[]);
+/// Converts a decoded primitive arrow array into the codec's wire form: per-row
+/// raw `i64` bits (null slots hold 0) + per-row presence flags from the array's
+/// null buffer. Bit conventions match the old def-level decode path exactly:
+/// INT32-backed values sign-extend, FLOAT is `f32::to_bits` zero-extended,
+/// DOUBLE is `f64::to_bits`, BOOL is 0/1, and date/time/timestamp logical
+/// types pass through as their raw INT32/INT64 physical values.
+fn arrow_primitive_to_page(array: &ArrayRef) -> Result<(Vec<i64>, Vec<bool>), String> {
+    use arrow::array::AsArray;
+    use arrow::datatypes as adt;
+    use arrow::datatypes::ArrowPrimitiveType;
+
+    fn conv<T: ArrowPrimitiveType>(
+        array: &ArrayRef,
+        to_bits: impl Fn(T::Native) -> i64,
+    ) -> (Vec<i64>, Vec<bool>) {
+        let a = array.as_primitive::<T>();
+        let mut longs = Vec::with_capacity(a.len());
+        let mut presence = Vec::with_capacity(a.len());
+        for i in 0..a.len() {
+            if a.is_valid(i) {
+                longs.push(to_bits(a.value(i)));
+                presence.push(true);
+            } else {
+                longs.push(0);
+                presence.push(false);
+            }
         }
+        (longs, presence)
     }
-    out
+
+    let out = match array.data_type() {
+        ArrowDataType::Boolean => {
+            let a = array.as_boolean();
+            let mut longs = Vec::with_capacity(a.len());
+            let mut presence = Vec::with_capacity(a.len());
+            for i in 0..a.len() {
+                if a.is_valid(i) {
+                    longs.push(if a.value(i) { 1 } else { 0 });
+                    presence.push(true);
+                } else {
+                    longs.push(0);
+                    presence.push(false);
+                }
+            }
+            (longs, presence)
+        }
+        ArrowDataType::Int8 => conv::<adt::Int8Type>(array, |v| v as i64),
+        ArrowDataType::Int16 => conv::<adt::Int16Type>(array, |v| v as i64),
+        ArrowDataType::Int32 => conv::<adt::Int32Type>(array, |v| v as i64),
+        ArrowDataType::Int64 => conv::<adt::Int64Type>(array, |v| v),
+        // Unsigned types are stored as their signed physical INT32/INT64
+        // counterparts; reinterpret through the signed type so the raw bits
+        // match what the old physical-value path produced.
+        ArrowDataType::UInt8 => conv::<adt::UInt8Type>(array, |v| v as i64),
+        ArrowDataType::UInt16 => conv::<adt::UInt16Type>(array, |v| v as i64),
+        ArrowDataType::UInt32 => conv::<adt::UInt32Type>(array, |v| (v as i32) as i64),
+        ArrowDataType::UInt64 => conv::<adt::UInt64Type>(array, |v| v as i64),
+        ArrowDataType::Float32 => conv::<adt::Float32Type>(array, |v| v.to_bits() as i64),
+        ArrowDataType::Float64 => conv::<adt::Float64Type>(array, |v| v.to_bits() as i64),
+        // Date/time/timestamp logical types: raw physical INT32/INT64 passthrough.
+        ArrowDataType::Date32 => conv::<adt::Date32Type>(array, |v| v as i64),
+        ArrowDataType::Date64 => conv::<adt::Date64Type>(array, |v| v),
+        ArrowDataType::Time32(adt::TimeUnit::Second) => {
+            conv::<adt::Time32SecondType>(array, |v| v as i64)
+        }
+        ArrowDataType::Time32(adt::TimeUnit::Millisecond) => {
+            conv::<adt::Time32MillisecondType>(array, |v| v as i64)
+        }
+        ArrowDataType::Time64(adt::TimeUnit::Microsecond) => {
+            conv::<adt::Time64MicrosecondType>(array, |v| v)
+        }
+        ArrowDataType::Time64(adt::TimeUnit::Nanosecond) => {
+            conv::<adt::Time64NanosecondType>(array, |v| v)
+        }
+        ArrowDataType::Timestamp(adt::TimeUnit::Second, _) => {
+            conv::<adt::TimestampSecondType>(array, |v| v)
+        }
+        ArrowDataType::Timestamp(adt::TimeUnit::Millisecond, _) => {
+            conv::<adt::TimestampMillisecondType>(array, |v| v)
+        }
+        ArrowDataType::Timestamp(adt::TimeUnit::Microsecond, _) => {
+            conv::<adt::TimestampMicrosecondType>(array, |v| v)
+        }
+        ArrowDataType::Timestamp(adt::TimeUnit::Nanosecond, _) => {
+            conv::<adt::TimestampNanosecondType>(array, |v| v)
+        }
+        ArrowDataType::Duration(adt::TimeUnit::Second) => {
+            conv::<adt::DurationSecondType>(array, |v| v)
+        }
+        ArrowDataType::Duration(adt::TimeUnit::Millisecond) => {
+            conv::<adt::DurationMillisecondType>(array, |v| v)
+        }
+        ArrowDataType::Duration(adt::TimeUnit::Microsecond) => {
+            conv::<adt::DurationMicrosecondType>(array, |v| v)
+        }
+        ArrowDataType::Duration(adt::TimeUnit::Nanosecond) => {
+            conv::<adt::DurationNanosecondType>(array, |v| v)
+        }
+        other => {
+            return Err(format!(
+                "page decode: unsupported arrow type {:?} for primitive column",
+                other
+            ))
+        }
+    };
+    Ok(out)
 }
 
-/// Expands dense non-null FIXED_LEN_BYTE_ARRAY values into a per-row slice vector.
-fn expand_flba<'a>(
-    presence: &[bool],
-    dense: &'a [parquet::data_type::FixedLenByteArray],
-) -> Vec<&'a [u8]> {
-    let mut out: Vec<&[u8]> = Vec::with_capacity(presence.len());
-    let mut di = 0usize;
-    for &present in presence {
-        if present {
-            out.push(dense[di].data());
-            di += 1;
-        } else {
-            out.push(&[]);
+/// Converts a decoded BYTE_ARRAY/FIXED_LEN_BYTE_ARRAY arrow array into per-row
+/// byte slices (null rows map to an empty slice, matching the old expand path)
+/// + per-row presence flags from the array's null buffer.
+fn arrow_bytes_to_page(array: &ArrayRef) -> Result<(Vec<&[u8]>, Vec<bool>), String> {
+    use arrow::array::AsArray;
+
+    fn conv<'a>(
+        len: usize,
+        is_valid: impl Fn(usize) -> bool,
+        value: impl Fn(usize) -> &'a [u8],
+    ) -> (Vec<&'a [u8]>, Vec<bool>) {
+        let mut slices: Vec<&[u8]> = Vec::with_capacity(len);
+        let mut presence = Vec::with_capacity(len);
+        for i in 0..len {
+            if is_valid(i) {
+                slices.push(value(i));
+                presence.push(true);
+            } else {
+                slices.push(&[]);
+                presence.push(false);
+            }
         }
+        (slices, presence)
     }
-    out
+
+    let out = match array.data_type() {
+        ArrowDataType::Utf8 => {
+            let a = array.as_string::<i32>();
+            conv(a.len(), |i| a.is_valid(i), |i| a.value(i).as_bytes())
+        }
+        ArrowDataType::LargeUtf8 => {
+            let a = array.as_string::<i64>();
+            conv(a.len(), |i| a.is_valid(i), |i| a.value(i).as_bytes())
+        }
+        ArrowDataType::Utf8View => {
+            let a = array.as_string_view();
+            conv(a.len(), |i| a.is_valid(i), |i| a.value(i).as_bytes())
+        }
+        ArrowDataType::Binary => {
+            let a = array.as_binary::<i32>();
+            conv(a.len(), |i| a.is_valid(i), |i| a.value(i))
+        }
+        ArrowDataType::LargeBinary => {
+            let a = array.as_binary::<i64>();
+            conv(a.len(), |i| a.is_valid(i), |i| a.value(i))
+        }
+        ArrowDataType::BinaryView => {
+            let a = array.as_binary_view();
+            conv(a.len(), |i| a.is_valid(i), |i| a.value(i))
+        }
+        ArrowDataType::FixedSizeBinary(_) => {
+            let a = array.as_fixed_size_binary();
+            conv(a.len(), |i| a.is_valid(i), |i| a.value(i))
+        }
+        other => {
+            return Err(format!(
+                "page decode: unsupported arrow type {:?} for byte-array column",
+                other
+            ))
+        }
+    };
+    Ok(out)
 }
 
 /// Writes a decoded primitive page (per-row raw bits + presence bitset) to the
@@ -1933,11 +2433,7 @@ unsafe fn write_primitive_page(
     // storing through a *mut i64 — out_value_buf is a u8 buffer with no
     // guaranteed 8-byte alignment, so an aligned i64 store would be UB.
     if !longs.is_empty() {
-        std::ptr::copy_nonoverlapping(
-            longs.as_ptr() as *const u8,
-            out_value_buf,
-            longs.len() * 8,
-        );
+        std::ptr::copy_nonoverlapping(longs.as_ptr() as *const u8, out_value_buf, longs.len() * 8);
     }
     write_presence_bitset(presence, out_presence_bitset, out_presence_bits_cap);
     Ok(RC_OK)
@@ -1986,4 +2482,587 @@ unsafe fn write_bytes_page(
 
     write_presence_bitset(presence, out_presence_bitset, out_presence_bits_cap);
     Ok(RC_OK)
+}
+
+#[cfg(test)]
+mod reader_tests {
+    use super::*;
+    use arrow::array::{
+        ArrayRef, BooleanArray, Date32Array, FixedSizeBinaryArray, Float32Array, Float64Array,
+        Int32Array, Int64Array, RecordBatch, StringArray, TimestampMillisecondArray,
+    };
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
+    use std::sync::mpsc;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    // -------------------------------------------------------------------
+    // Conversion helpers: arrow array -> (longs, presence) / (slices, presence)
+    // -------------------------------------------------------------------
+
+    fn int64_array(vals: Vec<Option<i64>>) -> ArrayRef {
+        Arc::new(Int64Array::from(vals))
+    }
+
+    #[test]
+    fn primitive_conversion_no_nulls() {
+        let (longs, presence) =
+            arrow_primitive_to_page(&int64_array(vec![Some(1), Some(-2), Some(i64::MAX)])).unwrap();
+        assert_eq!(longs, vec![1, -2, i64::MAX]);
+        assert_eq!(presence, vec![true, true, true]);
+    }
+
+    #[test]
+    fn primitive_conversion_null_at_start() {
+        let (longs, presence) =
+            arrow_primitive_to_page(&int64_array(vec![None, Some(7), Some(8)])).unwrap();
+        assert_eq!(longs, vec![0, 7, 8]);
+        assert_eq!(presence, vec![false, true, true]);
+    }
+
+    #[test]
+    fn primitive_conversion_null_in_middle() {
+        let (longs, presence) =
+            arrow_primitive_to_page(&int64_array(vec![Some(7), None, Some(8)])).unwrap();
+        assert_eq!(longs, vec![7, 0, 8]);
+        assert_eq!(presence, vec![true, false, true]);
+    }
+
+    #[test]
+    fn primitive_conversion_null_at_end() {
+        let (longs, presence) =
+            arrow_primitive_to_page(&int64_array(vec![Some(7), Some(8), None])).unwrap();
+        assert_eq!(longs, vec![7, 8, 0]);
+        assert_eq!(presence, vec![true, true, false]);
+    }
+
+    #[test]
+    fn primitive_conversion_all_null() {
+        let (longs, presence) =
+            arrow_primitive_to_page(&int64_array(vec![None, None, None])).unwrap();
+        assert_eq!(longs, vec![0, 0, 0]);
+        assert_eq!(presence, vec![false, false, false]);
+    }
+
+    #[test]
+    fn primitive_conversion_all_null_slice() {
+        // A sliced array exercises offset-carrying null buffers.
+        let base = int64_array(vec![Some(1), None, None, None, Some(5)]);
+        let sliced = base.slice(1, 3);
+        let (longs, presence) = arrow_primitive_to_page(&sliced).unwrap();
+        assert_eq!(longs, vec![0, 0, 0]);
+        assert_eq!(presence, vec![false, false, false]);
+    }
+
+    #[test]
+    fn primitive_conversion_raw_bits_per_type() {
+        // INT32 sign-extends.
+        let (longs, _) = arrow_primitive_to_page(
+            &(Arc::new(Int32Array::from(vec![Some(-1), Some(42)])) as ArrayRef),
+        )
+        .unwrap();
+        assert_eq!(longs, vec![-1i64, 42]);
+
+        // FLOAT = f32::to_bits zero-extended.
+        let (longs, _) = arrow_primitive_to_page(
+            &(Arc::new(Float32Array::from(vec![Some(-1.5f32)])) as ArrayRef),
+        )
+        .unwrap();
+        assert_eq!(longs, vec![(-1.5f32).to_bits() as i64]);
+
+        // DOUBLE = f64::to_bits.
+        let (longs, _) = arrow_primitive_to_page(
+            &(Arc::new(Float64Array::from(vec![Some(2.25f64)])) as ArrayRef),
+        )
+        .unwrap();
+        assert_eq!(longs, vec![2.25f64.to_bits() as i64]);
+
+        // BOOL = 0/1 with nulls as 0.
+        let (longs, presence) = arrow_primitive_to_page(
+            &(Arc::new(BooleanArray::from(vec![Some(true), None, Some(false)])) as ArrayRef),
+        )
+        .unwrap();
+        assert_eq!(longs, vec![1, 0, 0]);
+        assert_eq!(presence, vec![true, false, true]);
+
+        // Date32 / TimestampMillis pass raw physical values through.
+        let (longs, _) =
+            arrow_primitive_to_page(&(Arc::new(Date32Array::from(vec![Some(19000)])) as ArrayRef))
+                .unwrap();
+        assert_eq!(longs, vec![19000]);
+        let (longs, _) = arrow_primitive_to_page(
+            &(Arc::new(TimestampMillisecondArray::from(vec![Some(
+                1_700_000_000_000i64,
+            )])) as ArrayRef),
+        )
+        .unwrap();
+        assert_eq!(longs, vec![1_700_000_000_000]);
+    }
+
+    #[test]
+    fn bytes_conversion_nulls() {
+        let arr: ArrayRef = Arc::new(StringArray::from(vec![
+            None,
+            Some("ab"),
+            None,
+            Some(""),
+            Some("xyz"),
+            None,
+        ]));
+        let (slices, presence) = arrow_bytes_to_page(&arr).unwrap();
+        assert_eq!(
+            slices,
+            vec![
+                b"".as_ref(),
+                b"ab".as_ref(),
+                b"".as_ref(),
+                b"".as_ref(),
+                b"xyz".as_ref(),
+                b"".as_ref()
+            ]
+        );
+        assert_eq!(presence, vec![false, true, false, true, true, false]);
+    }
+
+    #[test]
+    fn bytes_conversion_fixed_size_binary() {
+        let arr: ArrayRef = Arc::new(
+            FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                vec![Some(vec![1u8, 2]), None, Some(vec![3u8, 4])].into_iter(),
+                2,
+            )
+            .unwrap(),
+        );
+        let (slices, presence) = arrow_bytes_to_page(&arr).unwrap();
+        assert_eq!(
+            slices,
+            vec![[1u8, 2].as_ref(), b"".as_ref(), [3u8, 4].as_ref()]
+        );
+        assert_eq!(presence, vec![true, false, true]);
+    }
+
+    // -------------------------------------------------------------------
+    // End-to-end FFM decode over real files (written with ArrowWriter)
+    // -------------------------------------------------------------------
+
+    fn write_file(path: &str, batch: &RecordBatch, page_row_limit: usize) {
+        let props = WriterProperties::builder()
+            .set_data_page_row_count_limit(page_row_limit)
+            .set_write_batch_size(page_row_limit)
+            .build();
+        let file = File::create(path).unwrap();
+        let mut w = ArrowWriter::try_new(file, batch.schema(), Some(props)).unwrap();
+        w.write(batch).unwrap();
+        w.close().unwrap();
+    }
+
+    fn open_handle(path: &str, col: &str, expected_type: i32) -> i64 {
+        let h = unsafe {
+            parquet_open_column_reader(
+                path.as_ptr(),
+                path.len() as i64,
+                col.as_ptr(),
+                col.len() as i64,
+                expected_type,
+            )
+        };
+        assert!(h >= 0, "open_column_reader failed: {}", h);
+        h
+    }
+
+    fn close_handle(handle: i64) {
+        let rc = unsafe { parquet_close_column_reader(handle) };
+        assert_eq!(rc, RC_OK);
+    }
+
+    struct Decoded {
+        first_row: i64,
+        last_row: i64,
+        longs: Vec<i64>,
+        bytes: Vec<u8>,
+        offsets: Vec<i32>,
+        presence_words: Vec<i64>,
+    }
+
+    impl Decoded {
+        fn present(&self, i: usize) -> bool {
+            (self.presence_words[i / 64] >> (i % 64)) & 1 == 1
+        }
+        fn rows(&self) -> usize {
+            (self.last_row - self.first_row + 1) as usize
+        }
+    }
+
+    /// Calls `parquet_decode_page_at_row` with generously sized buffers.
+    fn decode_at(handle: i64, row: i64, max_rows: usize, max_bytes: usize) -> Decoded {
+        let mut first = 0i64;
+        let mut last = 0i64;
+        let mut value_buf = vec![0u8; max_bytes.max(max_rows * 8)];
+        let mut actual_len = 0i64;
+        let mut offsets = vec![0i32; max_rows + 1];
+        let words = max_rows.div_ceil(64);
+        let mut presence = vec![0i64; words];
+        let rc = unsafe {
+            parquet_decode_page_at_row(
+                handle,
+                row,
+                &mut first,
+                &mut last,
+                value_buf.as_mut_ptr(),
+                value_buf.len() as i64,
+                &mut actual_len,
+                offsets.as_mut_ptr(),
+                offsets.len() as i64,
+                presence.as_mut_ptr(),
+                words as i64,
+            )
+        };
+        assert_eq!(rc, RC_OK, "decode_page_at_row returned {}", rc);
+        let rows = (last - first + 1) as usize;
+        let longs: Vec<i64> = (0..rows)
+            .map(|i| {
+                let mut b = [0u8; 8];
+                b.copy_from_slice(&value_buf[i * 8..i * 8 + 8]);
+                i64::from_ne_bytes(b)
+            })
+            .collect();
+        value_buf.truncate(actual_len.max(0) as usize);
+        Decoded {
+            first_row: first,
+            last_row: last,
+            longs,
+            bytes: value_buf,
+            offsets,
+            presence_words: presence,
+        }
+    }
+
+    #[test]
+    fn decode_page_int64_multi_page_with_nulls() {
+        let (_dir, path) = crate::test_utils::get_temp_file_path("int64_pages.parquet");
+        let total = 2500usize;
+        let vals: Vec<Option<i64>> = (0..total)
+            .map(|i| if i % 7 == 0 { None } else { Some(i as i64 * 3) })
+            .collect();
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vals.clone()))]).unwrap();
+        write_file(&path, &batch, 1000);
+
+        let h = open_handle(&path, "v", TYPE_INT64);
+        // A late row lands in a later page: the decode must cover exactly the
+        // page's rows and reproduce values + nulls.
+        let d = decode_at(h, 2200, total, 0);
+        assert!(d.first_row <= 2200 && 2200 <= d.last_row);
+        assert!(d.first_row > 0, "row 2200 should not be in the first page");
+        for i in 0..d.rows() {
+            let global = d.first_row as usize + i;
+            match vals[global] {
+                Some(v) => {
+                    assert!(d.present(i), "row {} should be present", global);
+                    assert_eq!(d.longs[i], v, "row {}", global);
+                }
+                None => {
+                    assert!(!d.present(i), "row {} should be null", global);
+                    assert_eq!(d.longs[i], 0);
+                }
+            }
+        }
+        close_handle(h);
+    }
+
+    #[test]
+    fn decode_page_utf8_dictionary_encoded() {
+        let (_dir, path) = crate::test_utils::get_temp_file_path("utf8_dict.parquet");
+        let total = 500usize;
+        // Heavily repeated strings → the default writer produces dictionary pages.
+        let vals: Vec<Option<&str>> = (0..total)
+            .map(|i| match i % 4 {
+                0 => Some("alpha"),
+                1 => Some("beta"),
+                2 => None,
+                _ => Some("gamma"),
+            })
+            .collect();
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, true)]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(vals.clone()))]).unwrap();
+        write_file(&path, &batch, 200);
+
+        let h = open_handle(&path, "s", TYPE_BYTE_ARRAY);
+        let d = decode_at(h, 250, total, total * 8);
+        for i in 0..d.rows() {
+            let global = d.first_row as usize + i;
+            let got = &d.bytes[d.offsets[i] as usize..d.offsets[i + 1] as usize];
+            match vals[global] {
+                Some(v) => {
+                    assert!(d.present(i), "row {} should be present", global);
+                    assert_eq!(got, v.as_bytes(), "row {}", global);
+                }
+                None => {
+                    assert!(!d.present(i), "row {} should be null", global);
+                    assert!(got.is_empty());
+                }
+            }
+        }
+        close_handle(h);
+    }
+
+    #[test]
+    fn decode_page_date32_and_timestamp_raw_bits() {
+        let (_dir, path) = crate::test_utils::get_temp_file_path("date_ts.parquet");
+        let total = 300usize;
+        let dates: Vec<Option<i32>> = (0..total)
+            .map(|i| {
+                if i % 5 == 0 {
+                    None
+                } else {
+                    Some(19000 + i as i32)
+                }
+            })
+            .collect();
+        let tss: Vec<Option<i64>> = (0..total)
+            .map(|i| {
+                if i % 3 == 0 {
+                    None
+                } else {
+                    Some(1_700_000_000_000 + i as i64)
+                }
+            })
+            .collect();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("d", DataType::Date32, true),
+            Field::new("t", DataType::Timestamp(TimeUnit::Millisecond, None), true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Date32Array::from(dates.clone())),
+                Arc::new(TimestampMillisecondArray::from(tss.clone())),
+            ],
+        )
+        .unwrap();
+        write_file(&path, &batch, 100);
+
+        // Date32 → physical INT32, timestamp-millis → physical INT64; raw bits
+        // must match the logical values exactly (same as the old def-level path).
+        let hd = open_handle(&path, "d", TYPE_INT32);
+        let d = decode_at(hd, 150, total, 0);
+        for i in 0..d.rows() {
+            let global = d.first_row as usize + i;
+            match dates[global] {
+                Some(v) => {
+                    assert!(d.present(i));
+                    assert_eq!(d.longs[i], v as i64, "date row {}", global);
+                }
+                None => assert!(!d.present(i)),
+            }
+        }
+        close_handle(hd);
+
+        let ht = open_handle(&path, "t", TYPE_INT64);
+        let t = decode_at(ht, 150, total, 0);
+        for i in 0..t.rows() {
+            let global = t.first_row as usize + i;
+            match tss[global] {
+                Some(v) => {
+                    assert!(t.present(i));
+                    assert_eq!(t.longs[i], v, "ts row {}", global);
+                }
+                None => assert!(!t.present(i)),
+            }
+        }
+        close_handle(ht);
+    }
+
+    #[test]
+    fn decode_overflow_reports_sizes_then_retry_succeeds() {
+        let (_dir, path) = crate::test_utils::get_temp_file_path("overflow.parquet");
+        let total = 400usize;
+        let vals: Vec<Option<i64>> = (0..total).map(|i| Some(i as i64)).collect();
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vals))]).unwrap();
+        write_file(&path, &batch, 1000);
+
+        let h = open_handle(&path, "v", TYPE_INT64);
+        let mut first = 0i64;
+        let mut last = 0i64;
+        let mut tiny = vec![0u8; 8];
+        let mut actual_len = 0i64;
+        let mut presence = vec![0i64; 1];
+        let rc = unsafe {
+            parquet_decode_page_at_row(
+                h,
+                0,
+                &mut first,
+                &mut last,
+                tiny.as_mut_ptr(),
+                tiny.len() as i64,
+                &mut actual_len,
+                std::ptr::null_mut(),
+                0,
+                presence.as_mut_ptr(),
+                1,
+            )
+        };
+        assert_eq!(rc, RC_OVERFLOW);
+        let rows = (last - first + 1) as usize;
+        assert_eq!(rows, total);
+        assert_eq!(actual_len, (total * 8) as i64);
+        // Grow-and-retry with the reported sizes succeeds.
+        let d = decode_at(h, 0, rows, actual_len as usize);
+        assert_eq!(d.rows(), total);
+        assert_eq!(d.longs[123], 123);
+        close_handle(h);
+    }
+
+    // -------------------------------------------------------------------
+    // Per-handle locking: decodes on distinct handles do not serialise
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn concurrent_decode_on_distinct_handles() {
+        let (_dir, path) = crate::test_utils::get_temp_file_path("concurrent.parquet");
+        let total = 200usize;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Int64, true),
+        ]));
+        let vals: Vec<Option<i64>> = (0..total).map(|i| Some(i as i64)).collect();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vals.clone())),
+                Arc::new(Int64Array::from(vals)),
+            ],
+        )
+        .unwrap();
+        write_file(&path, &batch, 1000);
+
+        let h1 = open_handle(&path, "a", TYPE_INT64);
+        let h2 = open_handle(&path, "b", TYPE_INT64);
+
+        // Hold handle 1's *state* lock (as an in-flight decode would).
+        let cell1 = state_for_handle(h1, "test").unwrap();
+        let guard1 = cell1.lock().unwrap();
+
+        // A decode on handle 2 must complete while handle 1's lock is held —
+        // with the old registry-wide mutex this would deadlock/time out.
+        let (tx, rx) = mpsc::channel();
+        let t2 = std::thread::spawn(move || {
+            let d = decode_at(h2, 10, 200, 0);
+            tx.send(d.rows()).unwrap();
+        });
+        let rows = rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("decode on handle 2 blocked while handle 1's state lock was held");
+        assert_eq!(rows, total);
+        t2.join().unwrap();
+
+        // And a decode on handle 1 itself must block until the lock is released.
+        let (tx1, rx1) = mpsc::channel();
+        let t1 = std::thread::spawn(move || {
+            let d = decode_at(h1, 10, 200, 0);
+            tx1.send(d.rows()).unwrap();
+        });
+        assert!(
+            rx1.recv_timeout(Duration::from_millis(300)).is_err(),
+            "decode on handle 1 should block while its state lock is held"
+        );
+        drop(guard1);
+        let rows = rx1
+            .recv_timeout(Duration::from_secs(10))
+            .expect("decode on handle 1 never completed after lock release");
+        assert_eq!(rows, total);
+        t1.join().unwrap();
+
+        close_handle(h1);
+        close_handle(h2);
+    }
+
+    // -------------------------------------------------------------------
+    // Sanity micro-benchmark: old low-level decode vs new arrow decode of a
+    // late page. Prints timings; run with `cargo test -- --nocapture`.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn bench_late_page_decode_old_vs_new() {
+        let (_dir, path) = crate::test_utils::get_temp_file_path("bench.parquet");
+        let total = 200_000usize;
+        let page_rows = 20_000usize;
+        let vals: Vec<Option<i64>> = (0..total)
+            .map(|i| if i % 11 == 0 { None } else { Some(i as i64) })
+            .collect();
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, true)]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vals))]).unwrap();
+        write_file(&path, &batch, page_rows);
+
+        let h = open_handle(&path, "v", TYPE_INT64);
+        let late_row = (total - page_rows / 2) as i64; // inside the last page
+
+        // Locate the page via the handle's state so both paths decode the
+        // exact same rows.
+        let cell = state_for_handle(h, "bench").unwrap();
+        let (rg_idx, local_first, page_num_rows) = {
+            let state = cell.lock().unwrap();
+            let p = state.page_for_row(late_row).unwrap();
+            let e = &state.pages[p];
+            (e.rg_idx, e.local_first_row, e.num_rows as usize)
+        };
+
+        let iters = 20;
+
+        // OLD path: fresh row-group reader + skip_records + read_records +
+        // def-level expansion (what parquet_decode_page_at_row used to do).
+        let old_start = Instant::now();
+        for _ in 0..iters {
+            let state = cell.lock().unwrap();
+            let rg = state.reader.get_row_group(rg_idx).unwrap();
+            let col = rg.get_column_reader(state.leaf_idx).unwrap();
+            let ColumnReader::Int64ColumnReader(mut r) = col else {
+                panic!("expected int64 column")
+            };
+            if local_first > 0 {
+                assert_eq!(
+                    r.skip_records(local_first as usize).unwrap(),
+                    local_first as usize
+                );
+            }
+            let mut def_levels: Vec<i16> = Vec::with_capacity(page_num_rows);
+            let mut values: Vec<i64> = Vec::with_capacity(page_num_rows);
+            let (records, _, _) = r
+                .read_records(page_num_rows, Some(&mut def_levels), None, &mut values)
+                .unwrap();
+            assert_eq!(records, page_num_rows);
+            let mut longs = Vec::with_capacity(page_num_rows);
+            let mut di = 0usize;
+            for d in def_levels.iter().take(page_num_rows) {
+                if *d == 1 {
+                    longs.push(values[di]);
+                    di += 1;
+                } else {
+                    longs.push(0);
+                }
+            }
+            std::hint::black_box(longs);
+        }
+        let old_per_iter = old_start.elapsed() / iters;
+
+        // NEW path: the FFM entry point (arrow RowSelection decode).
+        let new_start = Instant::now();
+        for _ in 0..iters {
+            let d = decode_at(h, late_row, page_num_rows, 0);
+            std::hint::black_box(d.longs);
+        }
+        let new_per_iter = new_start.elapsed() / iters;
+
+        println!(
+            "late-page decode ({} rows, page {} rows): old {:?}/iter, new {:?}/iter",
+            total, page_num_rows, old_per_iter, new_per_iter
+        );
+
+        close_handle(h);
+    }
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -2116,19 +2116,32 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
         | PhysicalType::INT64
         | PhysicalType::FLOAT
         | PhysicalType::DOUBLE => {
-            let (longs, presence) = arrow_primitive_to_page(&array)?;
-            if let Some(eid) = lc_eid {
-                crate::liquid_page_cache::put_page(eid, &longs, &presence);
+            match lc_eid {
+                // Liquid on: build owned vecs so we can backfill the cache, then write.
+                Some(eid) => {
+                    let (longs, presence) = arrow_primitive_to_page(&array)?;
+                    crate::liquid_page_cache::put_page(eid, &longs, &presence);
+                    write_primitive_page(
+                        &longs,
+                        &presence,
+                        out_value_buf,
+                        out_value_buf_cap,
+                        out_value_actual_len,
+                        out_presence_bitset,
+                        out_presence_bits_cap,
+                    )
+                }
+                // Liquid off (codec default): write straight from the arrow array into
+                // the FFM buffers, skipping the intermediate Vec<i64> + Vec<bool>.
+                None => write_primitive_page_from_arrow(
+                    &array,
+                    out_value_buf,
+                    out_value_buf_cap,
+                    out_value_actual_len,
+                    out_presence_bitset,
+                    out_presence_bits_cap,
+                ),
             }
-            write_primitive_page(
-                &longs,
-                &presence,
-                out_value_buf,
-                out_value_buf_cap,
-                out_value_actual_len,
-                out_presence_bitset,
-                out_presence_bits_cap,
-            )
         }
         PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY => {
             let (slices, presence) = arrow_bytes_to_page(&array)?;
@@ -2402,6 +2415,263 @@ fn arrow_bytes_to_page(array: &ArrayRef) -> Result<(Vec<&[u8]>, Vec<bool>), Stri
     Ok(out)
 }
 
+/// Fills the presence bitset directly from an arrow array's validity, no
+/// intermediate `Vec<bool>`. No-null arrays fill whole words with all-ones
+/// (last word masked to the row count); otherwise bits are set per valid row.
+/// Caller must have verified `out` holds at least `words` longs.
+unsafe fn write_presence_bits_from_array(array: &ArrayRef, out: *mut i64, words: usize) {
+    let n = array.len();
+    if array.null_count() == 0 {
+        // All present: set every bit, mask the tail of the last word.
+        for w in 0..words {
+            let base = w * 64;
+            let word = if base + 64 <= n {
+                u64::MAX
+            } else {
+                let rem = n - base; // 1..=63
+                (1u64 << rem) - 1
+            };
+            *out.add(w) = word as i64;
+        }
+        return;
+    }
+    for w in 0..words {
+        let mut bits: u64 = 0;
+        let base = w * 64;
+        for b in 0..64 {
+            let idx = base + b;
+            if idx >= n {
+                break;
+            }
+            if array.is_valid(idx) {
+                bits |= 1u64 << b;
+            }
+        }
+        *out.add(w) = bits as i64;
+    }
+}
+
+/// Direct-write primitive page: converts an arrow primitive array into the
+/// codec's wire form (per-row raw `i64` bits + presence bitset) writing STRAIGHT
+/// into the FFM out-buffers, skipping the intermediate `Vec<i64>` + `Vec<bool>`
+/// that `arrow_primitive_to_page` + `write_primitive_page` allocate. Used on the
+/// liquid-off decode path (the codec default); the liquid-on path still builds
+/// the vecs because `put_page` needs owned buffers.
+///
+/// Fast sub-case: when the array is an 8-byte-native primitive
+/// (Int64/Float64/Date64/Time64/Timestamp/Duration) with no nulls, its value
+/// buffer is already `[i64; n]` in native layout (f64 bits are bit-identical to
+/// the `to_bits` path), so the values are `memcpy`'d wholesale. All other types
+/// are written one slot at a time (null rows → 0), matching the bit conventions
+/// of `arrow_primitive_to_page` exactly.
+unsafe fn write_primitive_page_from_arrow(
+    array: &ArrayRef,
+    out_value_buf: *mut u8,
+    out_value_buf_cap: i64,
+    out_value_actual_len: *mut i64,
+    out_presence_bitset: *mut i64,
+    out_presence_bits_cap: i64,
+) -> Result<i64, String> {
+    use arrow::array::AsArray;
+    use arrow::datatypes as adt;
+    use arrow::datatypes::ArrowPrimitiveType;
+
+    let n = array.len();
+    let value_bytes = (n * 8) as i64;
+    if !out_value_actual_len.is_null() {
+        *out_value_actual_len = value_bytes;
+    }
+    let presence_words = ((n + 63) / 64) as i64;
+    if value_bytes > out_value_buf_cap
+        || (n > 0 && out_value_buf.is_null())
+        || presence_words > out_presence_bits_cap
+        || out_presence_bitset.is_null()
+    {
+        return Ok(RC_OVERFLOW);
+    }
+
+    write_presence_bits_from_array(array, out_presence_bitset, presence_words as usize);
+
+    // --- memcpy fast path: 8-byte-native, no nulls ---
+    let dt = array.data_type();
+    let src8: Option<*const u8> = if array.null_count() == 0 {
+        match dt {
+            ArrowDataType::Int64 => {
+                Some(array.as_primitive::<adt::Int64Type>().values().as_ptr() as *const u8)
+            }
+            ArrowDataType::Float64 => {
+                Some(array.as_primitive::<adt::Float64Type>().values().as_ptr() as *const u8)
+            }
+            ArrowDataType::Date64 => {
+                Some(array.as_primitive::<adt::Date64Type>().values().as_ptr() as *const u8)
+            }
+            ArrowDataType::Time64(adt::TimeUnit::Microsecond) => Some(
+                array
+                    .as_primitive::<adt::Time64MicrosecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            ArrowDataType::Time64(adt::TimeUnit::Nanosecond) => Some(
+                array
+                    .as_primitive::<adt::Time64NanosecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            ArrowDataType::Timestamp(adt::TimeUnit::Second, _) => Some(
+                array
+                    .as_primitive::<adt::TimestampSecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            ArrowDataType::Timestamp(adt::TimeUnit::Millisecond, _) => Some(
+                array
+                    .as_primitive::<adt::TimestampMillisecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            ArrowDataType::Timestamp(adt::TimeUnit::Microsecond, _) => Some(
+                array
+                    .as_primitive::<adt::TimestampMicrosecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            ArrowDataType::Timestamp(adt::TimeUnit::Nanosecond, _) => Some(
+                array
+                    .as_primitive::<adt::TimestampNanosecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            ArrowDataType::Duration(adt::TimeUnit::Second) => Some(
+                array
+                    .as_primitive::<adt::DurationSecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            ArrowDataType::Duration(adt::TimeUnit::Millisecond) => Some(
+                array
+                    .as_primitive::<adt::DurationMillisecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            ArrowDataType::Duration(adt::TimeUnit::Microsecond) => Some(
+                array
+                    .as_primitive::<adt::DurationMicrosecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            ArrowDataType::Duration(adt::TimeUnit::Nanosecond) => Some(
+                array
+                    .as_primitive::<adt::DurationNanosecondType>()
+                    .values()
+                    .as_ptr() as *const u8,
+            ),
+            _ => None,
+        }
+    } else {
+        None
+    };
+    if let Some(src) = src8 {
+        if n > 0 {
+            std::ptr::copy_nonoverlapping(src, out_value_buf, n * 8);
+        }
+        return Ok(RC_OK);
+    }
+
+    // --- one-pass write for widening / bit-packed / null-bearing types ---
+    // Writes every slot (null rows → 0) as native-endian i64 bytes; out_value_buf
+    // has no alignment guarantee so we copy bytes rather than store through *mut i64.
+    unsafe fn put_slot(out: *mut u8, i: usize, v: i64) {
+        std::ptr::copy_nonoverlapping(v.to_ne_bytes().as_ptr(), out.add(i * 8), 8);
+    }
+    fn one_pass<T: ArrowPrimitiveType>(
+        array: &ArrayRef,
+        out: *mut u8,
+        to_bits: impl Fn(T::Native) -> i64,
+    ) {
+        use arrow::array::AsArray;
+        let a = array.as_primitive::<T>();
+        for i in 0..a.len() {
+            let v = if a.is_valid(i) {
+                to_bits(a.value(i))
+            } else {
+                0
+            };
+            unsafe { put_slot(out, i, v) };
+        }
+    }
+
+    match dt {
+        ArrowDataType::Boolean => {
+            let a = array.as_boolean();
+            for i in 0..a.len() {
+                let v = if a.is_valid(i) && a.value(i) { 1 } else { 0 };
+                put_slot(out_value_buf, i, v);
+            }
+        }
+        ArrowDataType::Int8 => one_pass::<adt::Int8Type>(array, out_value_buf, |v| v as i64),
+        ArrowDataType::Int16 => one_pass::<adt::Int16Type>(array, out_value_buf, |v| v as i64),
+        ArrowDataType::Int32 => one_pass::<adt::Int32Type>(array, out_value_buf, |v| v as i64),
+        ArrowDataType::Int64 => one_pass::<adt::Int64Type>(array, out_value_buf, |v| v),
+        ArrowDataType::UInt8 => one_pass::<adt::UInt8Type>(array, out_value_buf, |v| v as i64),
+        ArrowDataType::UInt16 => one_pass::<adt::UInt16Type>(array, out_value_buf, |v| v as i64),
+        ArrowDataType::UInt32 => {
+            one_pass::<adt::UInt32Type>(array, out_value_buf, |v| (v as i32) as i64)
+        }
+        ArrowDataType::UInt64 => one_pass::<adt::UInt64Type>(array, out_value_buf, |v| v as i64),
+        ArrowDataType::Float32 => {
+            one_pass::<adt::Float32Type>(array, out_value_buf, |v| v.to_bits() as i64)
+        }
+        ArrowDataType::Float64 => {
+            one_pass::<adt::Float64Type>(array, out_value_buf, |v| v.to_bits() as i64)
+        }
+        ArrowDataType::Date32 => one_pass::<adt::Date32Type>(array, out_value_buf, |v| v as i64),
+        ArrowDataType::Date64 => one_pass::<adt::Date64Type>(array, out_value_buf, |v| v),
+        ArrowDataType::Time32(adt::TimeUnit::Second) => {
+            one_pass::<adt::Time32SecondType>(array, out_value_buf, |v| v as i64)
+        }
+        ArrowDataType::Time32(adt::TimeUnit::Millisecond) => {
+            one_pass::<adt::Time32MillisecondType>(array, out_value_buf, |v| v as i64)
+        }
+        ArrowDataType::Time64(adt::TimeUnit::Microsecond) => {
+            one_pass::<adt::Time64MicrosecondType>(array, out_value_buf, |v| v)
+        }
+        ArrowDataType::Time64(adt::TimeUnit::Nanosecond) => {
+            one_pass::<adt::Time64NanosecondType>(array, out_value_buf, |v| v)
+        }
+        ArrowDataType::Timestamp(adt::TimeUnit::Second, _) => {
+            one_pass::<adt::TimestampSecondType>(array, out_value_buf, |v| v)
+        }
+        ArrowDataType::Timestamp(adt::TimeUnit::Millisecond, _) => {
+            one_pass::<adt::TimestampMillisecondType>(array, out_value_buf, |v| v)
+        }
+        ArrowDataType::Timestamp(adt::TimeUnit::Microsecond, _) => {
+            one_pass::<adt::TimestampMicrosecondType>(array, out_value_buf, |v| v)
+        }
+        ArrowDataType::Timestamp(adt::TimeUnit::Nanosecond, _) => {
+            one_pass::<adt::TimestampNanosecondType>(array, out_value_buf, |v| v)
+        }
+        ArrowDataType::Duration(adt::TimeUnit::Second) => {
+            one_pass::<adt::DurationSecondType>(array, out_value_buf, |v| v)
+        }
+        ArrowDataType::Duration(adt::TimeUnit::Millisecond) => {
+            one_pass::<adt::DurationMillisecondType>(array, out_value_buf, |v| v)
+        }
+        ArrowDataType::Duration(adt::TimeUnit::Microsecond) => {
+            one_pass::<adt::DurationMicrosecondType>(array, out_value_buf, |v| v)
+        }
+        ArrowDataType::Duration(adt::TimeUnit::Nanosecond) => {
+            one_pass::<adt::DurationNanosecondType>(array, out_value_buf, |v| v)
+        }
+        other => {
+            return Err(format!(
+                "page decode: unsupported arrow type {:?} for primitive column",
+                other
+            ))
+        }
+    }
+    Ok(RC_OK)
+}
+
 /// Writes a decoded primitive page (per-row raw bits + presence bitset) to the
 /// caller buffers, or returns `RC_OVERFLOW` after recording the required value
 /// byte length.
@@ -2544,6 +2814,84 @@ mod reader_tests {
             arrow_primitive_to_page(&int64_array(vec![None, None, None])).unwrap();
         assert_eq!(longs, vec![0, 0, 0]);
         assert_eq!(presence, vec![false, false, false]);
+    }
+
+    /// The direct-write path (`write_primitive_page_from_arrow`, used when liquid is off)
+    /// must produce byte-identical value + presence buffers to the reference
+    /// `arrow_primitive_to_page` + `write_primitive_page` path (used when liquid is on).
+    #[test]
+    fn direct_write_matches_reference() {
+        fn reference(array: &ArrayRef) -> (Vec<u8>, Vec<i64>) {
+            let (longs, presence) = arrow_primitive_to_page(array).unwrap();
+            let vbytes = longs.len() * 8;
+            let pwords = (presence.len() + 63) / 64;
+            let mut vbuf = vec![0u8; vbytes.max(1)];
+            let mut pbuf = vec![0i64; pwords.max(1)];
+            let mut len = 0i64;
+            let rc = unsafe {
+                write_primitive_page(
+                    &longs,
+                    &presence,
+                    vbuf.as_mut_ptr(),
+                    vbytes as i64,
+                    &mut len,
+                    pbuf.as_mut_ptr(),
+                    pwords as i64,
+                )
+            }
+            .unwrap();
+            assert_eq!(rc, RC_OK);
+            (vbuf, pbuf)
+        }
+        fn direct(array: &ArrayRef) -> (Vec<u8>, Vec<i64>) {
+            let vbytes = array.len() * 8;
+            let pwords = (array.len() + 63) / 64;
+            let mut vbuf = vec![0u8; vbytes.max(1)];
+            let mut pbuf = vec![0i64; pwords.max(1)];
+            let mut len = 0i64;
+            let rc = unsafe {
+                write_primitive_page_from_arrow(
+                    array,
+                    vbuf.as_mut_ptr(),
+                    vbytes as i64,
+                    &mut len,
+                    pbuf.as_mut_ptr(),
+                    pwords as i64,
+                )
+            }
+            .unwrap();
+            assert_eq!(rc, RC_OK);
+            (vbuf, pbuf)
+        }
+        let cases: Vec<ArrayRef> = vec![
+            // memcpy fast path: Int64/Float64 no nulls
+            Arc::new(Int64Array::from(vec![
+                Some(1),
+                Some(-2),
+                Some(i64::MAX),
+                Some(0),
+            ])),
+            Arc::new(Float64Array::from(vec![Some(2.25), Some(-1.5), Some(0.0)])),
+            // nulls force the per-slot path
+            int64_array(vec![Some(7), None, Some(8), None, Some(9)]),
+            // widening + sign-extend
+            Arc::new(Int32Array::from(vec![Some(-1), Some(42), None])),
+            // float bits with a null
+            Arc::new(Float32Array::from(vec![Some(-1.5f32), None])),
+            // bool 0/1
+            Arc::new(BooleanArray::from(vec![Some(true), Some(false), None])),
+            // >64 rows to exercise multi-word presence + tail masking
+            Arc::new(Int64Array::from(
+                (0..100)
+                    .map(|i| if i % 7 == 0 { None } else { Some(i as i64) })
+                    .collect::<Vec<_>>(),
+            )),
+            // all-null
+            int64_array(vec![None, None, None]),
+        ];
+        for (i, c) in cases.iter().enumerate() {
+            assert_eq!(reference(c), direct(c), "mismatch on case {}", i);
+        }
     }
 
     #[test]

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -1551,6 +1551,24 @@ pub unsafe extern "C" fn parquet_liquid_cache_set_enabled(enabled: i32, max_memo
     crate::liquid_page_cache::set_enabled(enabled != 0, bytes);
 }
 
+/// Write the liquid page-cache counters `(hits, misses, backfills)` into `out` (3 i64 slots),
+/// so a benchmark can confirm the cache is actually serving hits. Returns the number of slots
+/// written (3), or 0 if `out` is null or `out_len < 3`.
+///
+/// # Safety
+/// `out` must point to at least `out_len` writable i64 slots.
+#[no_mangle]
+pub unsafe extern "C" fn parquet_liquid_cache_stats(out: *mut i64, out_len: i64) -> i64 {
+    if out.is_null() || out_len < 3 {
+        return 0;
+    }
+    let (hits, misses, backfills) = crate::liquid_page_cache::stats();
+    *out.add(0) = hits as i64;
+    *out.add(1) = misses as i64;
+    *out.add(2) = backfills as i64;
+    3
+}
+
 /// Slow-path single-value read at `row`.
 ///
 /// On success writes:
@@ -2094,10 +2112,11 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
         None
     };
     if let Some(eid) = lc_eid {
-        if let Some((longs, presence)) = crate::liquid_page_cache::get_page(eid) {
-            return write_primitive_page(
-                &longs,
-                &presence,
+        // Warm-run hot path: on a liquid hit, write the cached Int64Array straight into the FFM
+        // buffers (memcpy when no nulls) instead of rebuilding intermediate Vec<i64>+Vec<bool>.
+        if let Some(array) = crate::liquid_page_cache::get_page_array(eid) {
+            return write_primitive_page_from_arrow(
+                &array,
                 out_value_buf,
                 out_value_buf_cap,
                 out_value_actual_len,
@@ -2116,32 +2135,22 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
         | PhysicalType::INT64
         | PhysicalType::FLOAT
         | PhysicalType::DOUBLE => {
-            match lc_eid {
-                // Liquid on: build owned vecs so we can backfill the cache, then write.
-                Some(eid) => {
-                    let (longs, presence) = arrow_primitive_to_page(&array)?;
-                    crate::liquid_page_cache::put_page(eid, &longs, &presence);
-                    write_primitive_page(
-                        &longs,
-                        &presence,
-                        out_value_buf,
-                        out_value_buf_cap,
-                        out_value_actual_len,
-                        out_presence_bitset,
-                        out_presence_bits_cap,
-                    )
-                }
-                // Liquid off (codec default): write straight from the arrow array into
-                // the FFM buffers, skipping the intermediate Vec<i64> + Vec<bool>.
-                None => write_primitive_page_from_arrow(
-                    &array,
-                    out_value_buf,
-                    out_value_buf_cap,
-                    out_value_actual_len,
-                    out_presence_bitset,
-                    out_presence_bits_cap,
-                ),
+            // Liquid miss backfill: cache the decoded page (needs owned buffers), but still
+            // write the FFM output straight from the arrow array — no second copy.
+            if let Some(eid) = lc_eid {
+                let (longs, presence) = arrow_primitive_to_page(&array)?;
+                crate::liquid_page_cache::put_page(eid, &longs, &presence);
             }
+            // Both paths write from the arrow array (memcpy when 8-byte-native + no nulls),
+            // skipping the intermediate Vec<i64> + Vec<bool> on the FFM write.
+            write_primitive_page_from_arrow(
+                &array,
+                out_value_buf,
+                out_value_buf_cap,
+                out_value_actual_len,
+                out_presence_bitset,
+                out_presence_bits_cap,
+            )
         }
         PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY => {
             let (slices, presence) = arrow_bytes_to_page(&array)?;
@@ -2675,6 +2684,11 @@ unsafe fn write_primitive_page_from_arrow(
 /// Writes a decoded primitive page (per-row raw bits + presence bitset) to the
 /// caller buffers, or returns `RC_OVERFLOW` after recording the required value
 /// byte length.
+///
+/// Retained as the reference oracle for `direct_write_matches_reference`; production
+/// decode now writes straight from the arrow array via `write_primitive_page_from_arrow`
+/// on both the liquid-off and liquid-on paths.
+#[cfg(test)]
 unsafe fn write_primitive_page(
     longs: &[i64],
     presence: &[bool],

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -859,6 +859,9 @@ struct ColumnReaderState {
     /// `global_first_row`. Built once at `open()` from the Parquet OffsetIndex +
     /// ColumnIndex when present, else one entry per row group as a fallback.
     pages: Vec<PageEntry>,
+    /// Codec-local file id (path→id) for the cross-query decoded-page cache key. See
+    /// `crate::liquid_page_cache`.
+    liquid_file_id: u32,
 }
 
 /// One row-aligned page in the column (or one row group, in the no-page-index
@@ -939,6 +942,8 @@ impl ColumnReaderState {
             (leaf_idx, phys, max_rep > 0, max_def, row_count, rg_first_row, rg_num_rows, pages)
         };
 
+        let liquid_file_id = crate::liquid_page_cache::file_id(filename);
+
         Ok(ColumnReaderState {
             reader,
             leaf_idx,
@@ -949,6 +954,7 @@ impl ColumnReaderState {
             rg_first_row,
             rg_num_rows,
             pages,
+            liquid_file_id,
         })
     }
 
@@ -1204,6 +1210,16 @@ pub unsafe extern "C" fn parquet_open_column_reader_count() -> i64 {
         Ok(guard) => guard.len() as i64,
         Err(poisoned) => poisoned.into_inner().len() as i64,
     }
+}
+
+/// Enable/disable the cross-query decoded-page cache and set its memory budget (bytes).
+/// Called by Java at plugin init when the `parquet_liquid_cache` feature flag is on. When
+/// disabled (the default), `parquet_decode_page_at_row` never consults the cache and the decode
+/// path is unchanged. A `max_memory_bytes` of 0 leaves the liquid-cache default budget.
+#[no_mangle]
+pub unsafe extern "C" fn parquet_liquid_cache_set_enabled(enabled: i32, max_memory_bytes: i64) {
+    let bytes = if max_memory_bytes > 0 { max_memory_bytes as usize } else { 0 };
+    crate::liquid_page_cache::set_enabled(enabled != 0, bytes);
 }
 
 /// Slow-path single-value read at `row`.
@@ -1728,6 +1744,28 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
         *out_last_row = first_global + num_rows - 1;
     }
 
+    // Cross-query decoded-page cache (codec-owned liquid instance). When enabled, a hit serves the
+    // decoded page from the node-level cache and skips the Parquet decode below entirely; a miss
+    // decodes as usual and backfills the cache (see the primitive arms). Keyed by
+    // (file, column, page); primitives only. No-op when the feature flag is off.
+    let lc_eid = if crate::liquid_page_cache::enabled() {
+        Some(crate::liquid_page_cache::entry_id(
+            state.liquid_file_id,
+            state.leaf_idx as u32,
+            page_idx as u32,
+        ))
+    } else {
+        None
+    };
+    if let Some(eid) = lc_eid {
+        if let Some((longs, presence)) = crate::liquid_page_cache::get_page(eid) {
+            return write_primitive_page(
+                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
+                out_presence_bitset, out_presence_bits_cap,
+            );
+        }
+    }
+
     let rg = state.reader.get_row_group(rg_idx).map_err(|e| e.to_string())?;
     let col = rg.get_column_reader(state.leaf_idx).map_err(|e| e.to_string())?;
     let skip = local_first as usize;
@@ -1739,6 +1777,9 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
         ColumnReader::Int32ColumnReader(mut r) => {
             let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
             let longs = expand_primitive(&presence, &values, |v| v as i64);
+            if let Some(eid) = lc_eid {
+                crate::liquid_page_cache::put_page(eid, &longs, &presence);
+            }
             return write_primitive_page(
                 &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
                 out_presence_bitset, out_presence_bits_cap,
@@ -1747,6 +1788,9 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
         ColumnReader::Int64ColumnReader(mut r) => {
             let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
             let longs = expand_primitive(&presence, &values, |v| v);
+            if let Some(eid) = lc_eid {
+                crate::liquid_page_cache::put_page(eid, &longs, &presence);
+            }
             return write_primitive_page(
                 &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
                 out_presence_bitset, out_presence_bits_cap,
@@ -1755,6 +1799,9 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
         ColumnReader::FloatColumnReader(mut r) => {
             let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
             let longs = expand_primitive(&presence, &values, |v| v.to_bits() as i64);
+            if let Some(eid) = lc_eid {
+                crate::liquid_page_cache::put_page(eid, &longs, &presence);
+            }
             return write_primitive_page(
                 &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
                 out_presence_bitset, out_presence_bits_cap,
@@ -1763,6 +1810,9 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
         ColumnReader::DoubleColumnReader(mut r) => {
             let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
             let longs = expand_primitive(&presence, &values, |v| v.to_bits() as i64);
+            if let Some(eid) = lc_eid {
+                crate::liquid_page_cache::put_page(eid, &longs, &presence);
+            }
             return write_primitive_page(
                 &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
                 out_presence_bitset, out_presence_bits_cap,
@@ -1771,6 +1821,9 @@ pub unsafe extern "C" fn parquet_decode_page_at_row(
         ColumnReader::BoolColumnReader(mut r) => {
             let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
             let longs = expand_primitive(&presence, &values, |v| if v { 1i64 } else { 0i64 });
+            if let Some(eid) = lc_eid {
+                crate::liquid_page_cache::put_page(eid, &longs, &presence);
+            }
             return write_primitive_page(
                 &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
                 out_presence_bitset, out_presence_bits_cap,

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/ffm.rs
@@ -11,9 +11,13 @@
 //! Return convention: `>= 0` success, `< 0` error pointer (negate to get ptr,
 //! call `native_error_message`/`native_error_free`).
 
+use std::collections::HashMap;
 use std::slice;
 use std::str;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Mutex;
 
+use lazy_static::lazy_static;
 use native_bridge_common::{ffm_safe, log_debug};
 
 use crate::native_settings::NativeSettings;
@@ -782,4 +786,1151 @@ pub unsafe extern "C" fn parquet_get_pool_stats(out_buf: *mut i64) {
     for (i, val) in stats.iter().enumerate() {
         *out_buf.add(i) = *val as i64;
     }
+}
+// Parquet column reader (DocValues codec — Strategy 1 FFM bridge)
+// ---------------------------------------------------------------------------
+//
+// Read-only per-column random-access reader used by the Lucene
+// `ParquetDocValuesProducer`. The reader exposes the column's physical values
+// by row position so the Java side can materialise per-document doc values.
+//
+// Return convention (consistent with the rest of this file):
+//   - `>= 0` success. For reads, `0` (`RC_OK`) means "value(s) written"; the
+//     positive sentinel `RC_OVERFLOW` (1) means "caller buffer too small —
+//     required sizes were written to the out-parameters, retry once".
+//   - `< 0` error pointer (negate, then `native_error_message`/`native_error_free`).
+//
+// NOTE on the overflow sentinel: the design sketch refers to this as
+// `-E_OVERFLOW`, but this file's established FFM contract reserves *all*
+// negative returns for heap error pointers (negated `Box`/`CString` address).
+// Returning a small negative constant would be indistinguishable from — and
+// dereferenced as — an error pointer by `native_error_message`, corrupting
+// memory. We therefore signal overflow with a positive status code, mirroring
+// the existing `parquet_finalize_writer` precedent (`Ok(1)` == "no writer").
+// The Java wrapper checks `ret == RC_OVERFLOW` before the `ret < 0` error path.
+
+use std::fs::File;
+use std::sync::MutexGuard;
+
+use parquet::basic::Type as PhysicalType;
+use parquet::column::reader::{ColumnReader, ColumnReaderImpl};
+use parquet::data_type::DataType as ParquetDataType;
+use parquet::file::page_index::column_index::ColumnIndexMetaData;
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::file::serialized_reader::ReadOptionsBuilder;
+
+/// Read succeeded; value(s) written to the caller buffers.
+const RC_OK: i64 = 0;
+/// A caller buffer was too small. Required sizes were written to the
+/// out-parameters; the caller should grow its buffers and retry once.
+const RC_OVERFLOW: i64 = 1;
+
+/// `expected_type` discriminants exchanged with Java
+/// (matches `ParquetPhysicalType` on the Java side).
+const TYPE_INT32: i32 = 0;
+const TYPE_INT64: i32 = 1;
+const TYPE_FLOAT: i32 = 2;
+const TYPE_DOUBLE: i32 = 3;
+const TYPE_BOOL: i32 = 4;
+const TYPE_BYTE_ARRAY: i32 = 5;
+
+/// One open per-column reader. Owns the file handle (via `SerializedFileReader`)
+/// and the row-group layout needed to translate a global row position into a
+/// `(row_group, local_offset)` pair. Random access reopens the relevant row
+/// group per call — this is the documented *slow path*; the hot path goes
+/// through `parquet_decode_page_at_row` (page-resident caching on the Java side).
+struct ColumnReaderState {
+    reader: SerializedFileReader<File>,
+    /// Leaf column index within the Parquet schema descriptor.
+    leaf_idx: usize,
+    /// Physical type of the column (validated against the caller's expectation).
+    physical_type: PhysicalType,
+    /// True when the column has a repetition level > 0 (multi-valued).
+    repeated: bool,
+    /// Max definition level of the column (0 = required; >0 = optional/nested).
+    max_def_level: i16,
+    /// Total number of rows (records) in the file.
+    row_count: i64,
+    /// Global row index of the first row in each row group.
+    rg_first_row: Vec<i64>,
+    /// Number of rows in each row group.
+    rg_num_rows: Vec<i64>,
+    /// Per-page layout (Layer 3 jump table + Layer 4 page stats), ascending by
+    /// `global_first_row`. Built once at `open()` from the Parquet OffsetIndex +
+    /// ColumnIndex when present, else one entry per row group as a fallback.
+    pages: Vec<PageEntry>,
+}
+
+/// One row-aligned page in the column (or one row group, in the no-page-index
+/// fallback). All row indices are global (file-relative).
+struct PageEntry {
+    /// Global index of the first row in the page.
+    global_first_row: i64,
+    /// Number of rows in the page.
+    num_rows: i64,
+    /// Byte offset of the page in the file (Layer 3). 0 when unknown.
+    file_offset: i64,
+    /// Compressed page size in bytes (Layer 3). 0 when unknown.
+    compressed_size: i32,
+    /// Number of nulls in the page (Layer 4). -1 when unknown.
+    null_count: i64,
+    /// Min value raw bits (Layer 4); meaningful only for numeric columns with a
+    /// page index, else 0.
+    min_long: i64,
+    /// Max value raw bits (Layer 4); meaningful only for numeric columns with a
+    /// page index, else 0.
+    max_long: i64,
+    /// Row group containing the page.
+    rg_idx: usize,
+    /// Index of the page's first row within its row group.
+    local_first_row: i64,
+}
+
+impl ColumnReaderState {
+    fn open(filename: &str, column: &str, expected_type: i32) -> Result<ColumnReaderState, String> {
+        let file = File::open(filename).map_err(|e| format!("Failed to open '{}': {}", filename, e))?;
+        // Load the Parquet page index (OffsetIndex + ColumnIndex) so we can build
+        // the Layer 3/4 page layout. Falls back gracefully to row-group
+        // granularity if the file was written without a page index.
+        let options = ReadOptionsBuilder::new().with_page_index().build();
+        let reader = SerializedFileReader::new_with_options(file, options)
+            .map_err(|e| format!("Failed to read parquet '{}': {}", filename, e))?;
+
+        // Extract everything we need from the (borrowed) metadata inside a block so
+        // the borrow ends before we move `reader` into the returned struct.
+        let (leaf_idx, physical_type, repeated, max_def_level, row_count, rg_first_row, rg_num_rows, pages) = {
+            let metadata = reader.metadata();
+            let schema = metadata.file_metadata().schema_descr();
+
+            let mut found: Option<(usize, PhysicalType, i16, i16)> = None;
+            for i in 0..schema.num_columns() {
+                let descr = schema.column(i);
+                if descr.name() == column || descr.path().string() == column {
+                    found = Some((i, descr.physical_type(), descr.max_rep_level(), descr.max_def_level()));
+                    break;
+                }
+            }
+            let (leaf_idx, phys, max_rep, max_def) = found.ok_or_else(|| {
+                format!("Column '{}' not found in parquet file '{}'", column, filename)
+            })?;
+
+            let actual = physical_type_code(phys);
+            if actual != expected_type {
+                return Err(format!(
+                    "Column '{}' physical type mismatch in '{}': expected type code {}, found {:?} (code {})",
+                    column, filename, expected_type, phys, actual
+                ));
+            }
+
+            let n_rg = metadata.num_row_groups();
+            let mut rg_first_row = Vec::with_capacity(n_rg);
+            let mut rg_num_rows = Vec::with_capacity(n_rg);
+            let mut acc = 0i64;
+            for i in 0..n_rg {
+                let rn = metadata.row_group(i).num_rows();
+                rg_first_row.push(acc);
+                rg_num_rows.push(rn);
+                acc += rn;
+            }
+            let row_count = metadata.file_metadata().num_rows();
+
+            let pages = build_page_layout(metadata, leaf_idx, phys, &rg_first_row, &rg_num_rows);
+
+            (leaf_idx, phys, max_rep > 0, max_def, row_count, rg_first_row, rg_num_rows, pages)
+        };
+
+        Ok(ColumnReaderState {
+            reader,
+            leaf_idx,
+            physical_type,
+            repeated,
+            max_def_level,
+            row_count,
+            rg_first_row,
+            rg_num_rows,
+            pages,
+        })
+    }
+
+    /// Translate a global row position into `(row_group_index, local_offset)`.
+    fn locate(&self, row: i64) -> Result<(usize, i64), String> {
+        for i in 0..self.rg_first_row.len() {
+            let start = self.rg_first_row[i];
+            let end = start + self.rg_num_rows[i];
+            if row >= start && row < end {
+                return Ok((i, row - start));
+            }
+        }
+        Err(format!("Row {} not found in any row group (row count {})", row, self.row_count))
+    }
+
+    /// Find the index of the page containing global row `row` (binary search over
+    /// the ascending page layout).
+    fn page_for_row(&self, row: i64) -> Result<usize, String> {
+        // partition_point finds the first page whose global_first_row > row; the
+        // page we want is the one immediately before it.
+        let p = self.pages.partition_point(|e| e.global_first_row <= row);
+        if p == 0 {
+            return Err(format!("Row {} precedes the first page (row count {})", row, self.row_count));
+        }
+        let idx = p - 1;
+        let entry = &self.pages[idx];
+        if row >= entry.global_first_row && row < entry.global_first_row + entry.num_rows {
+            Ok(idx)
+        } else {
+            Err(format!("Row {} not found in any page (row count {})", row, self.row_count))
+        }
+    }
+}
+
+/// Builds the per-page layout for a column. Prefers the Parquet OffsetIndex +
+/// ColumnIndex (true page granularity); falls back to one entry per row group
+/// when the file has no page index.
+fn build_page_layout(
+    metadata: &parquet::file::metadata::ParquetMetaData,
+    leaf_idx: usize,
+    phys: PhysicalType,
+    rg_first_row: &[i64],
+    rg_num_rows: &[i64],
+) -> Vec<PageEntry> {
+    let n_rg = metadata.num_row_groups();
+    let offset_index = metadata.offset_index();
+    let column_index = metadata.column_index();
+
+    let mut pages: Vec<PageEntry> = Vec::new();
+
+    for rg in 0..n_rg {
+        let oi_pages = offset_index
+            .and_then(|oi| oi.get(rg))
+            .and_then(|cols| cols.get(leaf_idx));
+        let ci = column_index
+            .and_then(|ci| ci.get(rg))
+            .and_then(|cols| cols.get(leaf_idx));
+
+        match oi_pages {
+            Some(oi) => {
+                let locations = oi.page_locations();
+                let rg_rows = rg_num_rows[rg];
+                for (p, loc) in locations.iter().enumerate() {
+                    let local_first = loc.first_row_index;
+                    let next_local = if p + 1 < locations.len() {
+                        locations[p + 1].first_row_index
+                    } else {
+                        rg_rows
+                    };
+                    let num_rows = next_local - local_first;
+                    let null_count = ci.and_then(|c| c.null_count(p)).unwrap_or(-1);
+                    let (min_long, max_long) = ci
+                        .map(|c| page_min_max(c, p, phys))
+                        .unwrap_or((0, 0));
+                    pages.push(PageEntry {
+                        global_first_row: rg_first_row[rg] + local_first,
+                        num_rows,
+                        file_offset: loc.offset,
+                        compressed_size: loc.compressed_page_size,
+                        null_count,
+                        min_long,
+                        max_long,
+                        rg_idx: rg,
+                        local_first_row: local_first,
+                    });
+                }
+            }
+            None => {
+                // Fallback: treat the whole row group as a single "page".
+                let cc = metadata.row_group(rg).column(leaf_idx);
+                let null_count = cc
+                    .statistics()
+                    .and_then(|s| s.null_count_opt())
+                    .map(|n| n as i64)
+                    .unwrap_or(-1);
+                let compressed = cc.compressed_size().min(i32::MAX as i64) as i32;
+                pages.push(PageEntry {
+                    global_first_row: rg_first_row[rg],
+                    num_rows: rg_num_rows[rg],
+                    file_offset: cc.data_page_offset(),
+                    compressed_size: compressed,
+                    null_count,
+                    min_long: 0,
+                    max_long: 0,
+                    rg_idx: rg,
+                    local_first_row: 0,
+                });
+            }
+        }
+    }
+
+    pages
+}
+
+/// Extracts the per-page min/max as raw i64 bits from a typed ColumnIndex.
+/// Returns `(0, 0)` for byte-array/unsupported columns (binary min/max is not
+/// exchanged as i64; the Java side treats it as "unused").
+fn page_min_max(ci: &ColumnIndexMetaData, idx: usize, _phys: PhysicalType) -> (i64, i64) {
+    match ci {
+        ColumnIndexMetaData::INT32(p) => (
+            p.min_value(idx).map(|v| *v as i64).unwrap_or(0),
+            p.max_value(idx).map(|v| *v as i64).unwrap_or(0),
+        ),
+        ColumnIndexMetaData::INT64(p) => (
+            p.min_value(idx).copied().unwrap_or(0),
+            p.max_value(idx).copied().unwrap_or(0),
+        ),
+        ColumnIndexMetaData::FLOAT(p) => (
+            p.min_value(idx).map(|v| v.to_bits() as i64).unwrap_or(0),
+            p.max_value(idx).map(|v| v.to_bits() as i64).unwrap_or(0),
+        ),
+        ColumnIndexMetaData::DOUBLE(p) => (
+            p.min_value(idx).map(|v| v.to_bits() as i64).unwrap_or(0),
+            p.max_value(idx).map(|v| v.to_bits() as i64).unwrap_or(0),
+        ),
+        ColumnIndexMetaData::BOOLEAN(p) => (
+            p.min_value(idx).map(|v| if *v { 1 } else { 0 }).unwrap_or(0),
+            p.max_value(idx).map(|v| if *v { 1 } else { 0 }).unwrap_or(0),
+        ),
+        _ => (0, 0),
+    }
+}
+
+/// Maps a Parquet physical type to the Java-facing `expected_type` discriminant.
+/// Returns `-1` for unsupported physical types (e.g. INT96), which can never
+/// match a valid expectation and therefore surfaces as a clear mismatch error.
+fn physical_type_code(t: PhysicalType) -> i32 {
+    match t {
+        PhysicalType::BOOLEAN => TYPE_BOOL,
+        PhysicalType::INT32 => TYPE_INT32,
+        PhysicalType::INT64 => TYPE_INT64,
+        PhysicalType::FLOAT => TYPE_FLOAT,
+        PhysicalType::DOUBLE => TYPE_DOUBLE,
+        PhysicalType::BYTE_ARRAY => TYPE_BYTE_ARRAY,
+        PhysicalType::FIXED_LEN_BYTE_ARRAY => TYPE_BYTE_ARRAY,
+        PhysicalType::INT96 => -1,
+    }
+}
+
+/// Reads exactly one record (after skipping `skip` records) from a typed column
+/// reader, returning that record's non-null values. For a single-valued column
+/// the result holds 0 (null) or 1 value; for a repeated column it holds all the
+/// values of the record.
+fn read_record_values<T: ParquetDataType>(
+    r: &mut ColumnReaderImpl<T>,
+    skip: usize,
+) -> Result<Vec<T::T>, String> {
+    if skip > 0 {
+        let skipped = r.skip_records(skip).map_err(|e| e.to_string())?;
+        if skipped < skip {
+            return Err(format!("requested skip of {} records but only {} available", skip, skipped));
+        }
+    }
+    let mut def_levels: Vec<i16> = Vec::new();
+    let mut rep_levels: Vec<i16> = Vec::new();
+    let mut values: Vec<T::T> = Vec::new();
+    r.read_records(1, Some(&mut def_levels), Some(&mut rep_levels), &mut values)
+        .map_err(|e| e.to_string())?;
+    Ok(values)
+}
+
+lazy_static! {
+    /// Per-handle registry of open column readers, keyed by an opaque i64 handle.
+    /// Mirrors the writer-side handle pattern; serialised behind a single mutex
+    /// since column readers are not shared across threads.
+    static ref COLUMN_READERS: Mutex<HashMap<i64, ColumnReaderState>> = Mutex::new(HashMap::new());
+}
+
+/// Monotonic handle allocator. Always `>= 0`, so a returned handle is never
+/// confused with the `< 0` error-pointer convention.
+static NEXT_COLUMN_READER_HANDLE: AtomicI64 = AtomicI64::new(0);
+
+/// Locks the column-reader registry, converting a poisoned mutex into a normal
+/// FFM error instead of propagating the panic.
+fn lock_readers<'a>() -> Result<MutexGuard<'a, HashMap<i64, ColumnReaderState>>, String> {
+    COLUMN_READERS
+        .lock()
+        .map_err(|_| "column reader registry mutex poisoned".to_string())
+}
+
+/// Opens a per-column reader over `file` for `col`, validating that the column
+/// exists and its physical type matches `expected_type`
+/// (0=INT32,1=INT64,2=FLOAT,3=DOUBLE,4=BOOL,5=BYTE_ARRAY).
+///
+/// Returns `>= 0` handle id on success, `< 0` negated error pointer on failure.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_open_column_reader(
+    file_ptr: *const u8,
+    file_len: i64,
+    col_ptr: *const u8,
+    col_len: i64,
+    expected_type: i32,
+) -> i64 {
+    let filename = str_from_raw(file_ptr, file_len)
+        .map_err(|e| format!("parquet_open_column_reader file: {}", e))?
+        .to_string();
+    let column = str_from_raw(col_ptr, col_len)
+        .map_err(|e| format!("parquet_open_column_reader column: {}", e))?
+        .to_string();
+
+    let state = ColumnReaderState::open(&filename, &column, expected_type)?;
+
+    let handle = NEXT_COLUMN_READER_HANDLE.fetch_add(1, Ordering::SeqCst);
+    lock_readers()?.insert(handle, state);
+    log_debug!(
+        "parquet_open_column_reader: file={}, column={}, handle={}",
+        filename, column, handle
+    );
+    Ok(handle)
+}
+
+/// Closes a column reader handle and releases its file handle and buffers.
+/// Returns `0` on success, a `< 0` error pointer if the handle is unknown.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_close_column_reader(handle: i64) -> i64 {
+    match lock_readers()?.remove(&handle) {
+        Some(_) => {
+            log_debug!("parquet_close_column_reader: handle={}", handle);
+            Ok(RC_OK)
+        }
+        None => Err(format!("parquet_close_column_reader: unknown handle {}", handle)),
+    }
+}
+
+/// Debug-only symbol: returns the number of currently open column-reader
+/// handles. Used by Property 7 (native handle non-leakage). Never errors;
+/// recovers from a poisoned mutex rather than panicking.
+#[no_mangle]
+pub unsafe extern "C" fn parquet_open_column_reader_count() -> i64 {
+    match COLUMN_READERS.lock() {
+        Ok(guard) => guard.len() as i64,
+        Err(poisoned) => poisoned.into_inner().len() as i64,
+    }
+}
+
+/// Slow-path single-value read at `row`.
+///
+/// On success writes:
+///   - `out_present` = 1 if the row has a value, 0 if null/absent
+///   - `out_long`    = the value's raw bits for primitive columns:
+///                       INT32 sign-extended to i64; INT64 verbatim;
+///                       FLOAT  = `f32::to_bits` (zero-extended);
+///                       DOUBLE = `f64::to_bits`;
+///                       BOOL   = 0 or 1
+///   - for BYTE_ARRAY columns: the value bytes are copied into `out_buf` and
+///     `out_len` is set to the byte length (or -1 when the value is null).
+///
+/// Returns a `< 0` error pointer naming the row when `row >= row_count`, when
+/// the handle is unknown, or when `out_buf` is too small for a BYTE_ARRAY value
+/// (in which case `out_len` is set to the required length first).
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_read_value_at_row(
+    handle: i64,
+    row: i64,
+    out_present: *mut i64,
+    out_long: *mut i64,
+    out_buf: *mut u8,
+    out_buf_cap: i64,
+    out_len: *mut i64,
+) -> i64 {
+    let mut guard = lock_readers()?;
+    let state = guard
+        .get_mut(&handle)
+        .ok_or_else(|| format!("parquet_read_value_at_row: unknown handle {}", handle))?;
+
+    if row < 0 {
+        return Err(format!("parquet_read_value_at_row: negative row {}", row));
+    }
+    if row >= state.row_count {
+        return Err(format!(
+            "parquet_read_value_at_row: row {} out of range (row count {})",
+            row, state.row_count
+        ));
+    }
+
+    // Default outputs: absent value.
+    if !out_present.is_null() {
+        *out_present = 0;
+    }
+    if !out_long.is_null() {
+        *out_long = 0;
+    }
+    if !out_len.is_null() {
+        *out_len = -1;
+    }
+
+    let (rg_idx, local) = state.locate(row)?;
+    let rg = state.reader.get_row_group(rg_idx).map_err(|e| e.to_string())?;
+    let col = rg.get_column_reader(state.leaf_idx).map_err(|e| e.to_string())?;
+    let local = local as usize;
+
+    match col {
+        ColumnReader::Int32ColumnReader(mut r) => {
+            if let Some(v) = read_record_values(&mut r, local)?.first() {
+                set_present(out_present, out_long, *v as i64);
+            }
+        }
+        ColumnReader::Int64ColumnReader(mut r) => {
+            if let Some(v) = read_record_values(&mut r, local)?.first() {
+                set_present(out_present, out_long, *v);
+            }
+        }
+        ColumnReader::FloatColumnReader(mut r) => {
+            if let Some(v) = read_record_values(&mut r, local)?.first() {
+                set_present(out_present, out_long, v.to_bits() as i64);
+            }
+        }
+        ColumnReader::DoubleColumnReader(mut r) => {
+            if let Some(v) = read_record_values(&mut r, local)?.first() {
+                set_present(out_present, out_long, v.to_bits() as i64);
+            }
+        }
+        ColumnReader::BoolColumnReader(mut r) => {
+            if let Some(v) = read_record_values(&mut r, local)?.first() {
+                set_present(out_present, out_long, if *v { 1 } else { 0 });
+            }
+        }
+        ColumnReader::ByteArrayColumnReader(mut r) => {
+            if let Some(v) = read_record_values(&mut r, local)?.first() {
+                return write_bytes_value(v.data(), out_present, out_buf, out_buf_cap, out_len);
+            }
+        }
+        ColumnReader::FixedLenByteArrayColumnReader(mut r) => {
+            if let Some(v) = read_record_values(&mut r, local)?.first() {
+                return write_bytes_value(v.data(), out_present, out_buf, out_buf_cap, out_len);
+            }
+        }
+        ColumnReader::Int96ColumnReader(_) => {
+            return Err("parquet_read_value_at_row: INT96 columns are not supported".to_string());
+        }
+    }
+
+    Ok(RC_OK)
+}
+
+/// Marks a primitive value present and stores its raw bits.
+unsafe fn set_present(out_present: *mut i64, out_long: *mut i64, bits: i64) {
+    if !out_present.is_null() {
+        *out_present = 1;
+    }
+    if !out_long.is_null() {
+        *out_long = bits;
+    }
+}
+
+/// Copies a single BYTE_ARRAY value into the caller buffer. Sets `out_present=1`
+/// and `out_len` to the byte length. Returns `RC_OVERFLOW` (after recording the
+/// required length in `out_len`) when the value does not fit in `out_buf_cap`,
+/// so the caller can grow its buffer and retry once.
+unsafe fn write_bytes_value(
+    bytes: &[u8],
+    out_present: *mut i64,
+    out_buf: *mut u8,
+    out_buf_cap: i64,
+    out_len: *mut i64,
+) -> Result<i64, String> {
+    if !out_present.is_null() {
+        *out_present = 1;
+    }
+    let n = bytes.len();
+    if !out_len.is_null() {
+        *out_len = n as i64;
+    }
+    if (n as i64) > out_buf_cap || (n > 0 && out_buf.is_null()) {
+        return Ok(RC_OVERFLOW);
+    }
+    if n > 0 {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_buf, n);
+    }
+    Ok(RC_OK)
+}
+
+/// Slow-path repeated read at `row` for a repeated (multi-valued) column.
+///
+/// Capacity contract: `out_long_cap` is the maximum element count for *both*
+/// primitive and BYTE_ARRAY columns; `out_byte_offsets` (BYTE_ARRAY only) must
+/// have capacity `out_long_cap + 1`.
+///
+/// On success (`RC_OK`):
+///   - `out_count` = number of values at the row
+///   - primitive columns: raw bits (see `parquet_read_value_at_row`) written to
+///     `out_longs`
+///   - BYTE_ARRAY columns: concatenated bytes in `out_byte_buf`, CSR offsets
+///     (length `count + 1`) in `out_byte_offsets`
+///
+/// On `RC_OVERFLOW`: `out_count` holds the required element count. When the
+/// element count fits but only the byte buffer is too small, the full CSR
+/// offsets are still written so `out_byte_offsets[count]` reports the required
+/// total byte size, enabling a single retry.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_read_repeated_at_row(
+    handle: i64,
+    row: i64,
+    out_count: *mut i64,
+    out_longs: *mut i64,
+    out_long_cap: i64,
+    out_byte_buf: *mut u8,
+    out_byte_offsets: *mut i64,
+    out_byte_buf_cap: i64,
+) -> i64 {
+    let mut guard = lock_readers()?;
+    let state = guard
+        .get_mut(&handle)
+        .ok_or_else(|| format!("parquet_read_repeated_at_row: unknown handle {}", handle))?;
+
+    if row < 0 {
+        return Err(format!("parquet_read_repeated_at_row: negative row {}", row));
+    }
+    if row >= state.row_count {
+        return Err(format!(
+            "parquet_read_repeated_at_row: row {} out of range (row count {})",
+            row, state.row_count
+        ));
+    }
+
+    if !out_count.is_null() {
+        *out_count = 0;
+    }
+
+    let (rg_idx, local) = state.locate(row)?;
+    let rg = state.reader.get_row_group(rg_idx).map_err(|e| e.to_string())?;
+    let col = rg.get_column_reader(state.leaf_idx).map_err(|e| e.to_string())?;
+    let local = local as usize;
+
+    match col {
+        ColumnReader::Int32ColumnReader(mut r) => {
+            let vals = read_record_values(&mut r, local)?;
+            write_primitive_repeated(vals.iter().map(|v| *v as i64), vals.len(), out_count, out_longs, out_long_cap)
+        }
+        ColumnReader::Int64ColumnReader(mut r) => {
+            let vals = read_record_values(&mut r, local)?;
+            write_primitive_repeated(vals.iter().copied(), vals.len(), out_count, out_longs, out_long_cap)
+        }
+        ColumnReader::FloatColumnReader(mut r) => {
+            let vals = read_record_values(&mut r, local)?;
+            write_primitive_repeated(vals.iter().map(|v| v.to_bits() as i64), vals.len(), out_count, out_longs, out_long_cap)
+        }
+        ColumnReader::DoubleColumnReader(mut r) => {
+            let vals = read_record_values(&mut r, local)?;
+            write_primitive_repeated(vals.iter().map(|v| v.to_bits() as i64), vals.len(), out_count, out_longs, out_long_cap)
+        }
+        ColumnReader::BoolColumnReader(mut r) => {
+            let vals = read_record_values(&mut r, local)?;
+            write_primitive_repeated(vals.iter().map(|v| if *v { 1i64 } else { 0i64 }), vals.len(), out_count, out_longs, out_long_cap)
+        }
+        ColumnReader::ByteArrayColumnReader(mut r) => {
+            let vals = read_record_values(&mut r, local)?;
+            let slices: Vec<&[u8]> = vals.iter().map(|v| v.data()).collect();
+            write_bytes_repeated(&slices, out_count, out_long_cap, out_byte_buf, out_byte_offsets, out_byte_buf_cap)
+        }
+        ColumnReader::FixedLenByteArrayColumnReader(mut r) => {
+            let vals = read_record_values(&mut r, local)?;
+            let slices: Vec<&[u8]> = vals.iter().map(|v| v.data()).collect();
+            write_bytes_repeated(&slices, out_count, out_long_cap, out_byte_buf, out_byte_offsets, out_byte_buf_cap)
+        }
+        ColumnReader::Int96ColumnReader(_) => {
+            Err("parquet_read_repeated_at_row: INT96 columns are not supported".to_string())
+        }
+    }
+}
+
+/// Writes repeated primitive values to `out_longs`, or reports overflow.
+unsafe fn write_primitive_repeated(
+    values: impl Iterator<Item = i64>,
+    count: usize,
+    out_count: *mut i64,
+    out_longs: *mut i64,
+    out_long_cap: i64,
+) -> Result<i64, String> {
+    if !out_count.is_null() {
+        *out_count = count as i64;
+    }
+    if (count as i64) > out_long_cap || out_longs.is_null() {
+        return Ok(RC_OVERFLOW);
+    }
+    for (i, v) in values.enumerate() {
+        *out_longs.add(i) = v;
+    }
+    Ok(RC_OK)
+}
+
+/// Writes repeated BYTE_ARRAY values (CSR layout) to the caller buffers, or
+/// reports overflow with required sizes.
+unsafe fn write_bytes_repeated(
+    slices: &[&[u8]],
+    out_count: *mut i64,
+    out_long_cap: i64,
+    out_byte_buf: *mut u8,
+    out_byte_offsets: *mut i64,
+    out_byte_buf_cap: i64,
+) -> Result<i64, String> {
+    let count = slices.len();
+    let total_bytes: usize = slices.iter().map(|s| s.len()).sum();
+    if !out_count.is_null() {
+        *out_count = count as i64;
+    }
+
+    // Element-count overflow: cannot safely write offsets (capacity is count+1).
+    if (count as i64) > out_long_cap {
+        return Ok(RC_OVERFLOW);
+    }
+
+    // Element count fits: write the full CSR offsets so that, even on a byte
+    // overflow, out_byte_offsets[count] == total_bytes reports the required size.
+    if !out_byte_offsets.is_null() {
+        let mut acc = 0i64;
+        for (i, s) in slices.iter().enumerate() {
+            *out_byte_offsets.add(i) = acc;
+            acc += s.len() as i64;
+        }
+        *out_byte_offsets.add(count) = acc;
+    }
+
+    if (total_bytes as i64) > out_byte_buf_cap || (total_bytes > 0 && out_byte_buf.is_null()) {
+        return Ok(RC_OVERFLOW);
+    }
+
+    let mut acc = 0usize;
+    for s in slices {
+        if !s.is_empty() {
+            std::ptr::copy_nonoverlapping(s.as_ptr(), out_byte_buf.add(acc), s.len());
+        }
+        acc += s.len();
+    }
+    Ok(RC_OK)
+}
+
+// ---------------------------------------------------------------------------
+// Page-index loader + page decoder (DocValues codec — cache Layers 1-4)
+// ---------------------------------------------------------------------------
+//
+// These are the hot-path functions used by the Java `ParquetColumnReader`:
+//   - `parquet_get_column_num_pages`  — page count, so Java can pre-size buffers
+//   - `parquet_get_column_page_index` — Layer 3 jump table + Layer 4 page stats
+//   - `parquet_decode_page_at_row`    — Layer 1 values + Layer 2 presence bitset
+//
+// All row indices exchanged here are global (file-relative), consistent with
+// the Row ID = Doc ID invariant.
+
+/// Returns the number of pages in the column (`>= 0`), or a `< 0` error pointer
+/// for an unknown handle. Java reads this first to size the parallel arrays
+/// passed to `parquet_get_column_page_index`.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_get_column_num_pages(handle: i64) -> i64 {
+    let guard = lock_readers()?;
+    let state = guard
+        .get(&handle)
+        .ok_or_else(|| format!("parquet_get_column_num_pages: unknown handle {}", handle))?;
+    Ok(state.pages.len() as i64)
+}
+
+/// Layer 3 + 4: writes the column's per-page jump table and page statistics into
+/// caller-provided parallel arrays, each of capacity `out_buf_capacity`
+/// (= the page count from `parquet_get_column_num_pages`).
+///
+/// Arrays (length = page count):
+///   - `out_first_row`       global index of the page's first row
+///   - `out_file_offset`     byte offset of the page in the file (0 if unknown)
+///   - `out_compressed_size` compressed page size in bytes (0 if unknown)
+///   - `out_null_count`      nulls in the page, or -1 when unknown
+///   - `out_min_long`        per-page min raw bits (numeric only; 0 otherwise)
+///   - `out_max_long`        per-page max raw bits (numeric only; 0 otherwise)
+///
+/// `out_actual_pages` always receives the true page count. Returns `RC_OVERFLOW`
+/// (a positive sentinel) without writing the arrays when `out_buf_capacity` is
+/// smaller than the page count, so the caller can grow and retry. Returns a
+/// `< 0` error pointer for an unknown handle.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_get_column_page_index(
+    handle: i64,
+    out_first_row: *mut i64,
+    out_file_offset: *mut i64,
+    out_compressed_size: *mut i32,
+    out_null_count: *mut i64,
+    out_min_long: *mut i64,
+    out_max_long: *mut i64,
+    out_buf_capacity: i64,
+    out_actual_pages: *mut i64,
+) -> i64 {
+    let guard = lock_readers()?;
+    let state = guard
+        .get(&handle)
+        .ok_or_else(|| format!("parquet_get_column_page_index: unknown handle {}", handle))?;
+
+    let n = state.pages.len();
+    if !out_actual_pages.is_null() {
+        *out_actual_pages = n as i64;
+    }
+    if (n as i64) > out_buf_capacity {
+        return Ok(RC_OVERFLOW);
+    }
+
+    for (i, e) in state.pages.iter().enumerate() {
+        if !out_first_row.is_null() {
+            *out_first_row.add(i) = e.global_first_row;
+        }
+        if !out_file_offset.is_null() {
+            *out_file_offset.add(i) = e.file_offset;
+        }
+        if !out_compressed_size.is_null() {
+            *out_compressed_size.add(i) = e.compressed_size;
+        }
+        if !out_null_count.is_null() {
+            *out_null_count.add(i) = e.null_count;
+        }
+        if !out_min_long.is_null() {
+            *out_min_long.add(i) = e.min_long;
+        }
+        if !out_max_long.is_null() {
+            *out_max_long.add(i) = e.max_long;
+        }
+    }
+    Ok(RC_OK)
+}
+
+/// Decodes one page's worth of single-valued records, returning a per-row
+/// presence flag (`true` = value present) and the dense list of non-null values
+/// in row order. `skip` records are skipped first, then `num_rows` records are
+/// read. Works for required columns (`max_def_level == 0`, all present) and
+/// optional non-repeated columns.
+fn decode_page_records<T: ParquetDataType>(
+    r: &mut ColumnReaderImpl<T>,
+    skip: usize,
+    num_rows: usize,
+    max_def_level: i16,
+) -> Result<(Vec<bool>, Vec<T::T>), String> {
+    if skip > 0 {
+        let skipped = r.skip_records(skip).map_err(|e| e.to_string())?;
+        if skipped < skip {
+            return Err(format!(
+                "page decode: requested skip of {} records but only {} available",
+                skip, skipped
+            ));
+        }
+    }
+
+    let mut def_levels: Vec<i16> = Vec::with_capacity(num_rows);
+    let mut values: Vec<T::T> = Vec::with_capacity(num_rows);
+    let (records_read, _values_read, _levels_read) = r
+        .read_records(num_rows, Some(&mut def_levels), None, &mut values)
+        .map_err(|e| e.to_string())?;
+    if records_read < num_rows {
+        return Err(format!(
+            "page decode: expected {} records but read {}",
+            num_rows, records_read
+        ));
+    }
+
+    // Build the per-row presence vector. For required columns `read_records`
+    // ignores the def-level buffer and every row is present.
+    let presence = if max_def_level == 0 {
+        vec![true; num_rows]
+    } else {
+        def_levels.iter().take(num_rows).map(|d| *d == max_def_level).collect()
+    };
+    Ok((presence, values))
+}
+
+/// Packs a per-row presence slice into a little-endian `long[]` bitset (bit i set
+/// when row i is present), writing into `out` (capacity `out_words`). Returns the
+/// number of words required; on capacity shortfall writes nothing and the caller
+/// treats the positive required count as an overflow signal.
+unsafe fn write_presence_bitset(presence: &[bool], out: *mut i64, out_words: i64) -> i64 {
+    let words_needed = ((presence.len() + 63) / 64) as i64;
+    if words_needed > out_words || out.is_null() {
+        return words_needed;
+    }
+    for w in 0..words_needed as usize {
+        let mut bits: u64 = 0;
+        let base = w * 64;
+        for b in 0..64 {
+            let idx = base + b;
+            if idx >= presence.len() {
+                break;
+            }
+            if presence[idx] {
+                bits |= 1u64 << b;
+            }
+        }
+        *out.add(w) = bits as i64;
+    }
+    words_needed
+}
+
+/// Layer 1 + 2: decode the page containing global row `row` into caller buffers.
+///
+/// On success (`RC_OK`):
+///   - `out_first_row` / `out_last_row` = inclusive global row range of the page
+///   - primitive columns: per-row raw bits written to `out_value_buf`
+///     (interpreted as `long[]`, one slot per row; null rows hold 0);
+///     `out_value_actual_len` = `rows * 8`
+///   - BYTE_ARRAY columns: concatenated value bytes in `out_value_buf`, per-row
+///     CSR offsets (length `rows + 1`) in `out_byte_offsets`;
+///     `out_value_actual_len` = total bytes used
+///   - `out_presence_bitset` = packed `long[]`, one bit per row
+///
+/// On `RC_OVERFLOW` (a positive sentinel): `out_first_row`, `out_last_row` and
+/// `out_value_actual_len` are populated so the caller can size every buffer
+/// (values = `out_value_actual_len` bytes; offsets = `rows + 1`; presence =
+/// `ceil(rows / 64)` words) and retry once. Returns a `< 0` error pointer for an
+/// unknown handle, an out-of-range row, or a repeated (multi-valued) column.
+#[ffm_safe]
+#[no_mangle]
+pub unsafe extern "C" fn parquet_decode_page_at_row(
+    handle: i64,
+    row: i64,
+    out_first_row: *mut i64,
+    out_last_row: *mut i64,
+    out_value_buf: *mut u8,
+    out_value_buf_cap: i64,
+    out_value_actual_len: *mut i64,
+    out_byte_offsets: *mut i32,
+    out_byte_offsets_cap: i64,
+    out_presence_bitset: *mut i64,
+    out_presence_bits_cap: i64,
+) -> i64 {
+    let mut guard = lock_readers()?;
+    let state = guard
+        .get_mut(&handle)
+        .ok_or_else(|| format!("parquet_decode_page_at_row: unknown handle {}", handle))?;
+
+    if row < 0 || row >= state.row_count {
+        return Err(format!(
+            "parquet_decode_page_at_row: row {} out of range (row count {})",
+            row, state.row_count
+        ));
+    }
+    if state.repeated {
+        return Err(format!(
+            "parquet_decode_page_at_row: column is repeated (multi-valued); use parquet_read_repeated_at_row (handle {})",
+            handle
+        ));
+    }
+
+    let page_idx = state.page_for_row(row)?;
+    // Copy out the page's coordinates before borrowing the reader mutably.
+    let (rg_idx, local_first, num_rows, first_global) = {
+        let e = &state.pages[page_idx];
+        (e.rg_idx, e.local_first_row, e.num_rows, e.global_first_row)
+    };
+    let num_rows_usize = num_rows as usize;
+    let max_def_level = state.max_def_level;
+    let physical_type = state.physical_type;
+
+    // Always report the page row range so the caller can bound its cache and
+    // size buffers even on the overflow path.
+    if !out_first_row.is_null() {
+        *out_first_row = first_global;
+    }
+    if !out_last_row.is_null() {
+        *out_last_row = first_global + num_rows - 1;
+    }
+
+    let rg = state.reader.get_row_group(rg_idx).map_err(|e| e.to_string())?;
+    let col = rg.get_column_reader(state.leaf_idx).map_err(|e| e.to_string())?;
+    let skip = local_first as usize;
+
+    // Decode the page into per-row presence + raw-bit values (primitives) or a
+    // backing byte buffer + CSR offsets (BYTE_ARRAY), then validate caller
+    // capacities and either copy out or signal overflow.
+    match col {
+        ColumnReader::Int32ColumnReader(mut r) => {
+            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
+            let longs = expand_primitive(&presence, &values, |v| v as i64);
+            return write_primitive_page(
+                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
+                out_presence_bitset, out_presence_bits_cap,
+            );
+        }
+        ColumnReader::Int64ColumnReader(mut r) => {
+            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
+            let longs = expand_primitive(&presence, &values, |v| v);
+            return write_primitive_page(
+                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
+                out_presence_bitset, out_presence_bits_cap,
+            );
+        }
+        ColumnReader::FloatColumnReader(mut r) => {
+            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
+            let longs = expand_primitive(&presence, &values, |v| v.to_bits() as i64);
+            return write_primitive_page(
+                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
+                out_presence_bitset, out_presence_bits_cap,
+            );
+        }
+        ColumnReader::DoubleColumnReader(mut r) => {
+            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
+            let longs = expand_primitive(&presence, &values, |v| v.to_bits() as i64);
+            return write_primitive_page(
+                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
+                out_presence_bitset, out_presence_bits_cap,
+            );
+        }
+        ColumnReader::BoolColumnReader(mut r) => {
+            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
+            let longs = expand_primitive(&presence, &values, |v| if v { 1i64 } else { 0i64 });
+            return write_primitive_page(
+                &longs, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
+                out_presence_bitset, out_presence_bits_cap,
+            );
+        }
+        ColumnReader::ByteArrayColumnReader(mut r) => {
+            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
+            let slices = expand_bytes(&presence, &values);
+            return write_bytes_page(
+                &slices, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
+                out_byte_offsets, out_byte_offsets_cap, out_presence_bitset, out_presence_bits_cap,
+            );
+        }
+        ColumnReader::FixedLenByteArrayColumnReader(mut r) => {
+            let (presence, values) = decode_page_records(&mut r, skip, num_rows_usize, max_def_level)?;
+            let slices = expand_flba(&presence, &values);
+            return write_bytes_page(
+                &slices, &presence, out_value_buf, out_value_buf_cap, out_value_actual_len,
+                out_byte_offsets, out_byte_offsets_cap, out_presence_bitset, out_presence_bits_cap,
+            );
+        }
+        ColumnReader::Int96ColumnReader(_) => {
+            let _ = physical_type; // silence unused in this arm
+            Err("parquet_decode_page_at_row: INT96 columns are not supported".to_string())
+        }
+    }
+}
+
+/// Expands dense non-null primitive values into a per-row `i64` slot vector
+/// (null rows hold 0), applying `to_bits` to each present value.
+fn expand_primitive<T: Copy>(presence: &[bool], dense: &[T], to_bits: impl Fn(T) -> i64) -> Vec<i64> {
+    let mut out = Vec::with_capacity(presence.len());
+    let mut di = 0usize;
+    for &present in presence {
+        if present {
+            out.push(to_bits(dense[di]));
+            di += 1;
+        } else {
+            out.push(0);
+        }
+    }
+    out
+}
+
+/// Expands dense non-null BYTE_ARRAY values into a per-row slice vector (null
+/// rows map to an empty slice).
+fn expand_bytes<'a>(presence: &[bool], dense: &'a [parquet::data_type::ByteArray]) -> Vec<&'a [u8]> {
+    let mut out: Vec<&[u8]> = Vec::with_capacity(presence.len());
+    let mut di = 0usize;
+    for &present in presence {
+        if present {
+            out.push(dense[di].data());
+            di += 1;
+        } else {
+            out.push(&[]);
+        }
+    }
+    out
+}
+
+/// Expands dense non-null FIXED_LEN_BYTE_ARRAY values into a per-row slice vector.
+fn expand_flba<'a>(
+    presence: &[bool],
+    dense: &'a [parquet::data_type::FixedLenByteArray],
+) -> Vec<&'a [u8]> {
+    let mut out: Vec<&[u8]> = Vec::with_capacity(presence.len());
+    let mut di = 0usize;
+    for &present in presence {
+        if present {
+            out.push(dense[di].data());
+            di += 1;
+        } else {
+            out.push(&[]);
+        }
+    }
+    out
+}
+
+/// Writes a decoded primitive page (per-row raw bits + presence bitset) to the
+/// caller buffers, or returns `RC_OVERFLOW` after recording the required value
+/// byte length.
+unsafe fn write_primitive_page(
+    longs: &[i64],
+    presence: &[bool],
+    out_value_buf: *mut u8,
+    out_value_buf_cap: i64,
+    out_value_actual_len: *mut i64,
+    out_presence_bitset: *mut i64,
+    out_presence_bits_cap: i64,
+) -> Result<i64, String> {
+    let value_bytes = (longs.len() * 8) as i64;
+    if !out_value_actual_len.is_null() {
+        *out_value_actual_len = value_bytes;
+    }
+
+    let presence_words = ((presence.len() + 63) / 64) as i64;
+    if value_bytes > out_value_buf_cap
+        || out_value_buf.is_null()
+        || presence_words > out_presence_bits_cap
+        || out_presence_bitset.is_null()
+    {
+        return Ok(RC_OVERFLOW);
+    }
+
+    // Write values as native-endian i64 words (Java reads them as a long[] via
+    // a MemorySegment using native byte order). Copy raw bytes rather than
+    // storing through a *mut i64 — out_value_buf is a u8 buffer with no
+    // guaranteed 8-byte alignment, so an aligned i64 store would be UB.
+    if !longs.is_empty() {
+        std::ptr::copy_nonoverlapping(
+            longs.as_ptr() as *const u8,
+            out_value_buf,
+            longs.len() * 8,
+        );
+    }
+    write_presence_bitset(presence, out_presence_bitset, out_presence_bits_cap);
+    Ok(RC_OK)
+}
+
+/// Writes a decoded BYTE_ARRAY page (concatenated bytes + CSR offsets + presence
+/// bitset) to the caller buffers, or returns `RC_OVERFLOW` after recording the
+/// required total byte length.
+unsafe fn write_bytes_page(
+    slices: &[&[u8]],
+    presence: &[bool],
+    out_value_buf: *mut u8,
+    out_value_buf_cap: i64,
+    out_value_actual_len: *mut i64,
+    out_byte_offsets: *mut i32,
+    out_byte_offsets_cap: i64,
+    out_presence_bitset: *mut i64,
+    out_presence_bits_cap: i64,
+) -> Result<i64, String> {
+    let total_bytes: usize = slices.iter().map(|s| s.len()).sum();
+    if !out_value_actual_len.is_null() {
+        *out_value_actual_len = total_bytes as i64;
+    }
+
+    let offsets_needed = (slices.len() + 1) as i64;
+    let presence_words = ((presence.len() + 63) / 64) as i64;
+    if (total_bytes as i64) > out_value_buf_cap
+        || (total_bytes > 0 && out_value_buf.is_null())
+        || offsets_needed > out_byte_offsets_cap
+        || out_byte_offsets.is_null()
+        || presence_words > out_presence_bits_cap
+        || out_presence_bitset.is_null()
+    {
+        return Ok(RC_OVERFLOW);
+    }
+
+    let mut acc: i32 = 0;
+    for (i, s) in slices.iter().enumerate() {
+        *out_byte_offsets.add(i) = acc;
+        if !s.is_empty() {
+            std::ptr::copy_nonoverlapping(s.as_ptr(), out_value_buf.add(acc as usize), s.len());
+        }
+        acc += s.len() as i32;
+    }
+    *out_byte_offsets.add(slices.len()) = acc;
+
+    write_presence_bitset(presence, out_presence_bitset, out_presence_bits_cap);
+    Ok(RC_OK)
 }

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/lib.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/lib.rs
@@ -14,6 +14,7 @@ mod tests;
 
 pub mod writer;
 pub mod ffm;
+pub mod liquid_page_cache;
 pub mod memory;
 pub mod native_settings;
 pub mod field_config;

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/liquid_page_cache.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/liquid_page_cache.rs
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+//! Codec-owned, cross-query decoded-page cache backed by liquid-cache's core API.
+//!
+//! The Parquet DocValues codec's `PageCache` is per-query scratch: every query re-decodes the
+//! same Parquet pages. This module gives the codec a **node-level** (process-lifetime) cache of
+//! decoded primitive pages so a later query reuses a page an earlier query already decoded —
+//! the cross-query tier the codec otherwise lacks.
+//!
+//! Design (v1):
+//! - A single process-global `Arc<LiquidCache>` (liquid core), built lazily. This is a
+//!   **codec-owned** instance, independent of the DataFusion/PPL liquid cache — same technology,
+//!   separate instance and keyspace. Sharing the DataFusion instance is a later optimization.
+//! - Entries are keyed by `(file_id, column_id, page_idx)` packed into liquid's `EntryID` (a
+//!   `usize`). `file_id` comes from a codec-local path→id registry, so the key carries file
+//!   identity (and Parquet's immutable-file/generation model means changed data = new path =
+//!   new key = automatic miss — no invalidation logic needed).
+//! - Values are cached as an Arrow `Int64Array` (with a null buffer derived from the page's
+//!   presence bits). On a hit we convert back to the raw `Vec<i64>` + `Vec<bool>` the codec's
+//!   `write_primitive_page` already consumes, so the Java/PageCache/per-doc path is byte-identical
+//!   whether the page was decoded or served from cache.
+//! - liquid's `insert`/`get` are async; we drive them on a dedicated single-threaded tokio runtime
+//!   via `block_on`, mirroring `merge::io_task`'s `OnceLock<Runtime>` pattern (the codec's FFM
+//!   entry points are synchronous `extern "C"`).
+//!
+//! Primitives only (INT32/INT64/date → i64 words). BYTE_ARRAY/keyword pages are not cached here.
+//! Gated by `set_enabled(true)` from Java; when disabled every entry point is a cheap no-op and the
+//! codec's decode path is unchanged.
+
+use std::collections::HashMap;
+use std::future::IntoFuture;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use arrow::array::{Array, ArrayRef, Int64Array};
+use liquid_cache::cache::{EntryID, LiquidCache, LiquidCacheBuilder};
+use tokio::runtime::Runtime;
+
+/// The process-global codec-owned decoded-page cache. Built on first use (or via `init`).
+static CACHE: OnceLock<Arc<LiquidCache>> = OnceLock::new();
+
+/// Dedicated runtime for driving liquid's async `insert`/`get` from the synchronous FFM path.
+static RT: OnceLock<Runtime> = OnceLock::new();
+
+/// Master on/off switch, set by Java at init. Off by default → the codec decode path is untouched.
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Configured max memory budget for the cache (bytes). Applied when the cache is first built.
+static MAX_MEMORY_BYTES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Codec-local file path → small integer id registry, so entries carry file identity without
+/// depending on DataFusion's file numbering.
+static FILE_IDS: OnceLock<Mutex<HashMap<String, u32>>> = OnceLock::new();
+
+/// Enable/disable the cache and set the memory budget. Called by Java at plugin init when the
+/// `parquet_liquid_cache` feature flag is on. A `max_memory_bytes` of 0 leaves the liquid default.
+pub fn set_enabled(enabled: bool, max_memory_bytes: usize) {
+    MAX_MEMORY_BYTES.store(max_memory_bytes, Ordering::Relaxed);
+    ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// True when the cache should be consulted. Cheap relaxed load on the hot path.
+#[inline]
+pub fn enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+fn runtime() -> &'static Runtime {
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("liquid_page_cache: failed to build tokio runtime")
+    })
+}
+
+fn cache() -> &'static Arc<LiquidCache> {
+    CACHE.get_or_init(|| {
+        let mut builder = LiquidCacheBuilder::new();
+        let budget = MAX_MEMORY_BYTES.load(Ordering::Relaxed);
+        if budget > 0 {
+            builder = builder.with_max_memory_bytes(budget);
+        }
+        runtime().block_on(builder.build())
+    })
+}
+
+/// Resolve (or assign) a stable small id for a Parquet file path. Codec-local; independent of any
+/// DataFusion file numbering.
+pub fn file_id(path: &str) -> u32 {
+    let map = FILE_IDS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = map.lock().expect("liquid_page_cache: file id registry poisoned");
+    let next = guard.len() as u32;
+    *guard.entry(path.to_string()).or_insert(next)
+}
+
+/// Pack `(file_id, column_id, page_idx)` into a liquid `EntryID`. u16 column id + u32 page fit
+/// alongside the file id in a usize on 64-bit targets.
+#[inline]
+pub fn entry_id(file_id: u32, column_id: u32, page_idx: u32) -> EntryID {
+    let v = ((file_id as usize) << 48) | ((column_id as usize) << 32) | (page_idx as usize);
+    EntryID::from(v)
+}
+
+/// Look up a cached decoded page. Returns `(longs, presence)` in the exact form the decode arms
+/// produce (`longs[i]` valid iff `presence[i]`), or `None` on a miss.
+pub fn get_page(eid: EntryID) -> Option<(Vec<i64>, Vec<bool>)> {
+    let array: ArrayRef = runtime().block_on(cache().get(&eid).read())?;
+    let int_array = array.as_any().downcast_ref::<Int64Array>()?;
+    let len = int_array.len();
+    let mut longs = Vec::with_capacity(len);
+    let mut presence = Vec::with_capacity(len);
+    for i in 0..len {
+        if int_array.is_null(i) {
+            longs.push(0);
+            presence.push(false);
+        } else {
+            longs.push(int_array.value(i));
+            presence.push(true);
+        }
+    }
+    Some((longs, presence))
+}
+
+/// Cache a decoded primitive page. `longs[i]` is meaningful only where `presence[i]` is true;
+/// null rows are stored as Arrow nulls so a later `get_page` reconstructs presence exactly.
+pub fn put_page(eid: EntryID, longs: &[i64], presence: &[bool]) {
+    debug_assert_eq!(longs.len(), presence.len());
+    let array: Int64Array = longs
+        .iter()
+        .zip(presence.iter())
+        .map(|(&v, &present)| if present { Some(v) } else { None })
+        .collect();
+    let array_ref: ArrayRef = Arc::new(array);
+    // Best-effort: a CacheFull error just means this page is not cached this time.
+    // `insert`/`get` return builder types that implement `IntoFuture`, so convert before block_on.
+    let _ = runtime().block_on(cache().insert(eid, array_ref).into_future());
+}

--- a/sandbox/plugins/parquet-data-format/src/main/rust/src/liquid_page_cache.rs
+++ b/sandbox/plugins/parquet-data-format/src/main/rust/src/liquid_page_cache.rs
@@ -54,6 +54,23 @@ static ENABLED: AtomicBool = AtomicBool::new(false);
 /// Configured max memory budget for the cache (bytes). Applied when the cache is first built.
 static MAX_MEMORY_BYTES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
+/// Observability counters, so a benchmark can confirm the liquid path is actually exercised
+/// (a "liquid-on" run that is all misses tells you nothing about the hit path). `hits` counts
+/// pages served from the cache, `misses` counts lookups that fell through to decode, `backfills`
+/// counts pages inserted after a miss.
+static HITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static MISSES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static BACKFILLS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Snapshot of the cache counters: `(hits, misses, backfills)`.
+pub fn stats() -> (u64, u64, u64) {
+    (
+        HITS.load(Ordering::Relaxed),
+        MISSES.load(Ordering::Relaxed),
+        BACKFILLS.load(Ordering::Relaxed),
+    )
+}
+
 /// Codec-local file path → small integer id registry, so entries carry file identity without
 /// depending on DataFusion's file numbering.
 static FILE_IDS: OnceLock<Mutex<HashMap<String, u32>>> = OnceLock::new();
@@ -95,7 +112,9 @@ fn cache() -> &'static Arc<LiquidCache> {
 /// DataFusion file numbering.
 pub fn file_id(path: &str) -> u32 {
     let map = FILE_IDS.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut guard = map.lock().expect("liquid_page_cache: file id registry poisoned");
+    let mut guard = map
+        .lock()
+        .expect("liquid_page_cache: file id registry poisoned");
     let next = guard.len() as u32;
     *guard.entry(path.to_string()).or_insert(next)
 }
@@ -106,6 +125,30 @@ pub fn file_id(path: &str) -> u32 {
 pub fn entry_id(file_id: u32, column_id: u32, page_idx: u32) -> EntryID {
     let v = ((file_id as usize) << 48) | ((column_id as usize) << 32) | (page_idx as usize);
     EntryID::from(v)
+}
+
+/// Look up a cached decoded page as the raw cached `ArrayRef` (an `Int64Array`), or `None` on
+/// a miss. The caller writes it straight into the FFM out-buffers via
+/// `write_primitive_page_from_arrow`, avoiding the per-element `Vec<i64>` + `Vec<bool>` rebuild
+/// that `get_page` performs. This is the warm-run hot path (every page is a hit), so skipping
+/// the rebuild matters. Returns `None` (falls back to decode) if the entry isn't an
+/// `Int64Array`, so the contract stays identical to `get_page`.
+pub fn get_page_array(eid: EntryID) -> Option<ArrayRef> {
+    let array: ArrayRef = match runtime().block_on(cache().get(&eid).read()) {
+        Some(a) => a,
+        None => {
+            MISSES.fetch_add(1, Ordering::Relaxed);
+            return None;
+        }
+    };
+    // Only the Int64Array layout is cached (see put_page); guard the downcast so a future
+    // change to the cached type falls back to decode instead of mis-reading.
+    if array.as_any().downcast_ref::<Int64Array>().is_none() {
+        MISSES.fetch_add(1, Ordering::Relaxed);
+        return None;
+    }
+    HITS.fetch_add(1, Ordering::Relaxed);
+    Some(array)
 }
 
 /// Look up a cached decoded page. Returns `(longs, presence)` in the exact form the decode arms
@@ -140,5 +183,10 @@ pub fn put_page(eid: EntryID, longs: &[i64], presence: &[bool]) {
     let array_ref: ArrayRef = Arc::new(array);
     // Best-effort: a CacheFull error just means this page is not cached this time.
     // `insert`/`get` return builder types that implement `IntoFuture`, so convert before block_on.
-    let _ = runtime().block_on(cache().insert(eid, array_ref).into_future());
+    if runtime()
+        .block_on(cache().insert(eid, array_ref).into_future())
+        .is_ok()
+    {
+        BACKFILLS.fetch_add(1, Ordering::Relaxed);
+    }
 }

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetColumnReaderTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetColumnReaderTests.java
@@ -1,0 +1,199 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.bridge;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.opensearch.nativebridge.spi.ArrowExport;
+import org.opensearch.parquet.codec.ParquetPhysicalType;
+import org.opensearch.parquet.codec.cache.BufferPool;
+import org.opensearch.parquet.codec.cache.ColumnPageIndex;
+import org.opensearch.parquet.codec.cache.PageCache;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Unit tests for {@link ParquetColumnReader} (task 2.4). Writes a small Parquet file with
+ * the native writer, then exercises single/repeated reads, null handling, error paths, the
+ * page index, and page-decode cache population.
+ */
+public class ParquetColumnReaderTests extends OpenSearchTestCase {
+
+    private BufferAllocator allocator;
+    private Schema schema;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RustBridge.initLogger();
+        allocator = new RootAllocator();
+        schema = new Schema(
+            List.of(
+                new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null),
+                new Field("name", FieldType.nullable(new ArrowType.Utf8()), null),
+                new Field("score", FieldType.nullable(new ArrowType.Int(64, true)), null)
+            )
+        );
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        allocator.close();
+        super.tearDown();
+    }
+
+    public void testReadIntColumnSingleValues() throws Exception {
+        Path file = writeFile(new int[] { 10, 20, 30 }, new String[] { "alice", "bob", "carol" }, new long[] { 100L, 200L, 300L });
+        try (BufferPool pool = new BufferPool(); ParquetColumnReader r = open(file, "id", ParquetPhysicalType.INT32, false, pool)) {
+            assertEquals(new ParquetColumnReader.Value(true, 10L), r.readValueAtRow(0));
+            assertEquals(new ParquetColumnReader.Value(true, 20L), r.readValueAtRow(1));
+            assertEquals(new ParquetColumnReader.Value(true, 30L), r.readValueAtRow(2));
+        }
+    }
+
+    public void testReadBinaryColumnWithNull() throws Exception {
+        Path file = writeFileWithNullName(new int[] { 1, 2, 3 }, new String[] { "alice", null, "carol" }, new long[] { 1, 2, 3 });
+        try (BufferPool pool = new BufferPool(); ParquetColumnReader r = open(file, "name", ParquetPhysicalType.BYTE_ARRAY, false, pool)) {
+            assertEquals("alice", new String(r.readBytesAtRow(0), StandardCharsets.UTF_8));
+            assertNull(r.readBytesAtRow(1));
+            assertEquals("carol", new String(r.readBytesAtRow(2), StandardCharsets.UTF_8));
+        }
+    }
+
+    public void testRowOutOfRangeThrows() throws Exception {
+        Path file = writeFile(new int[] { 1, 2 }, new String[] { "a", "b" }, new long[] { 1, 2 });
+        try (BufferPool pool = new BufferPool(); ParquetColumnReader r = open(file, "id", ParquetPhysicalType.INT32, false, pool)) {
+            IOException e = expectThrows(IOException.class, () -> r.readValueAtRow(99));
+            assertTrue("error should name the row: " + e.getMessage(), e.getMessage().contains("99"));
+        }
+    }
+
+    public void testMissingColumnThrows() throws Exception {
+        Path file = writeFile(new int[] { 1 }, new String[] { "a" }, new long[] { 1 });
+        try (BufferPool pool = new BufferPool()) {
+            IOException e = expectThrows(IOException.class, () -> open(file, "nope", ParquetPhysicalType.INT32, false, pool));
+            assertTrue("error should name the missing column: " + e.getMessage(), e.getMessage().contains("nope"));
+        }
+    }
+
+    public void testTypeMismatchThrows() throws Exception {
+        Path file = writeFile(new int[] { 1 }, new String[] { "a" }, new long[] { 1 });
+        try (BufferPool pool = new BufferPool()) {
+            // id is INT32 — asking for BYTE_ARRAY must fail.
+            IOException e = expectThrows(IOException.class, () -> open(file, "id", ParquetPhysicalType.BYTE_ARRAY, false, pool));
+            assertTrue(
+                "error should mention a mismatch: " + e.getMessage(),
+                e.getMessage().toLowerCase(java.util.Locale.ROOT).contains("mismatch")
+            );
+        }
+    }
+
+    public void testPageIndexAndDecode() throws Exception {
+        Path file = writeFile(new int[] { 10, 20, 30 }, new String[] { "a", "b", "c" }, new long[] { 1, 2, 3 });
+        try (BufferPool pool = new BufferPool(); ParquetColumnReader r = open(file, "id", ParquetPhysicalType.INT32, false, pool)) {
+            ColumnPageIndex idx = r.pageIndex();
+            assertTrue("expected at least one page", idx.pageCount() >= 1);
+            assertEquals(0L, idx.firstRowOf(0));
+            assertEquals(3L, idx.totalRows());
+            assertEquals(0, idx.pageForRow(0));
+            assertEquals(0, idx.pageForRow(2));
+
+            r.loadPageContaining(1);
+            PageCache cache = r.cache();
+            assertNotNull("page should be cached", cache);
+            assertEquals(0L, cache.firstRow);
+            assertEquals(2L, cache.lastRow);
+            assertTrue(cache.isPresent(1));
+            assertEquals(20L, cache.valueAt(1));
+            assertEquals(10L, cache.valueAt(0));
+            assertEquals(30L, cache.valueAt(2));
+        }
+    }
+
+    public void testCloseIsIdempotentAndHandlesDoNotLeak() throws Exception {
+        Path file = writeFile(new int[] { 1, 2 }, new String[] { "a", "b" }, new long[] { 1, 2 });
+        long before = RustBridge.openColumnReaderCount();
+        try (BufferPool pool = new BufferPool()) {
+            ParquetColumnReader r = open(file, "id", ParquetPhysicalType.INT32, false, pool);
+            assertEquals(before + 1, RustBridge.openColumnReaderCount());
+            r.close();
+            r.close(); // idempotent
+            assertEquals(before, RustBridge.openColumnReaderCount());
+        }
+    }
+
+    // ── helpers ──
+
+    private static ParquetColumnReader open(Path file, String col, ParquetPhysicalType type, boolean repeated, BufferPool pool)
+        throws IOException {
+        return ParquetColumnReader.open(file, col, type, repeated, pool);
+    }
+
+    private Path writeFile(int[] ids, String[] names, long[] scores) throws Exception {
+        return writeFileWithNullName(ids, names, scores);
+    }
+
+    private Path writeFileWithNullName(int[] ids, String[] names, long[] scores) throws Exception {
+        Path file = createTempDir().resolve("colreader.parquet");
+        NativeParquetWriter writer = new NativeParquetWriter(file.toString());
+        try (ArrowExport schemaExport = exportSchema()) {
+            writer.initialize("test-index", schemaExport.getSchemaAddress(), ParquetSortConfig.empty(), 0L);
+        }
+        try (ArrowExport export = exportData(ids, names, scores)) {
+            writer.write(export.getArrayAddress(), export.getSchemaAddress());
+        }
+        writer.flush();
+        writer.sync();
+        return file;
+    }
+
+    private ArrowExport exportSchema() {
+        ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
+        Data.exportSchema(allocator, schema, null, arrowSchema);
+        return new ArrowExport(null, arrowSchema);
+    }
+
+    private ArrowExport exportData(int[] ids, String[] names, long[] scores) {
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector idVec = (IntVector) root.getVector("id");
+            VarCharVector nameVec = (VarCharVector) root.getVector("name");
+            BigIntVector scoreVec = (BigIntVector) root.getVector("score");
+            for (int i = 0; i < ids.length; i++) {
+                idVec.setSafe(i, ids[i]);
+                if (names[i] == null) {
+                    nameVec.setNull(i);
+                } else {
+                    nameVec.setSafe(i, names[i].getBytes(StandardCharsets.UTF_8));
+                }
+                scoreVec.setSafe(i, scores[i]);
+            }
+            root.setRowCount(ids.length);
+
+            ArrowArray array = ArrowArray.allocateNew(allocator);
+            ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
+            Data.exportVectorSchemaRoot(allocator, root, null, array, arrowSchema);
+            return new ArrowExport(array, arrowSchema);
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetColumnReaderTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/bridge/ParquetColumnReaderTests.java
@@ -164,7 +164,6 @@ public class ParquetColumnReaderTests extends OpenSearchTestCase {
             writer.write(export.getArrayAddress(), export.getSchemaAddress());
         }
         writer.flush();
-        writer.sync();
         return file;
     }
 

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/FieldTypeMappingTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/FieldTypeMappingTests.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.lucene.index.DocValuesType;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link FieldTypeMapping} (task 4.3): the OpenSearch mapping type → Lucene DV
+ * type + Parquet physical type table, and the compatibility {@code validate} guard.
+ */
+public class FieldTypeMappingTests extends OpenSearchTestCase {
+
+    public void testNumericMappings() {
+        assertMapping("boolean", DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.BOOL);
+        assertMapping("byte", DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT32);
+        assertMapping("short", DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT32);
+        assertMapping("integer", DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT32);
+        assertMapping("long", DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT64);
+        assertMapping("float", DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.FLOAT);
+        assertMapping("double", DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.DOUBLE);
+        assertMapping("date", DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT64);
+        assertMapping("date_nanos", DocValuesType.NUMERIC, DocValuesType.SORTED_NUMERIC, ParquetPhysicalType.INT64);
+    }
+
+    public void testKeywordAndIpMappings() {
+        assertMapping("keyword", DocValuesType.SORTED, DocValuesType.SORTED_SET, ParquetPhysicalType.BYTE_ARRAY);
+        assertMapping("ip", DocValuesType.SORTED, DocValuesType.SORTED_SET, ParquetPhysicalType.BYTE_ARRAY);
+    }
+
+    public void testTextAndBinaryMappings() {
+        assertMapping("text", DocValuesType.BINARY, DocValuesType.NONE, ParquetPhysicalType.BYTE_ARRAY);
+        assertMapping("binary", DocValuesType.BINARY, DocValuesType.NONE, ParquetPhysicalType.BYTE_ARRAY);
+    }
+
+    public void testUnsupportedTypeThrows() {
+        assertFalse(FieldTypeMapping.isSupported("geo_point"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> FieldTypeMapping.forType("geo_point"));
+        assertTrue(e.getMessage().contains("geo_point"));
+    }
+
+    public void testValidateAcceptsSingleAndMultiValuedForms() {
+        // long supports NUMERIC (single) and SORTED_NUMERIC (multi).
+        FieldTypeMapping.validate("age", "long", DocValuesType.NUMERIC);
+        FieldTypeMapping.validate("ages", "long", DocValuesType.SORTED_NUMERIC);
+        // keyword supports SORTED (single) and SORTED_SET (multi).
+        FieldTypeMapping.validate("tag", "keyword", DocValuesType.SORTED);
+        FieldTypeMapping.validate("tags", "keyword", DocValuesType.SORTED_SET);
+    }
+
+    public void testValidateRejectsIncompatibleDvType() {
+        // Requesting NUMERIC for a keyword field must fail and name the field + type.
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> FieldTypeMapping.validate("tag", "keyword", DocValuesType.NUMERIC)
+        );
+        assertTrue(e.getMessage().contains("tag"));
+        assertTrue(e.getMessage().contains("keyword"));
+    }
+
+    public void testValidateRejectsUnsupportedMappingType() {
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> FieldTypeMapping.validate("loc", "geo_point", DocValuesType.BINARY)
+        );
+        assertTrue(e.getMessage().contains("loc"));
+        assertTrue(e.getMessage().contains("geo_point"));
+    }
+
+    private static void assertMapping(String type, DocValuesType single, DocValuesType multi, ParquetPhysicalType physical) {
+        FieldTypeMapping.Mapping m = FieldTypeMapping.forType(type);
+        assertEquals("single-valued DV for " + type, single, m.singleValued());
+        assertEquals("multi-valued DV for " + type, multi, m.multiValued());
+        assertEquals("physical type for " + type, physical, m.physical());
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/ParquetSegmentLayoutTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/ParquetSegmentLayoutTests.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.SegmentInfo;
+import org.apache.lucene.index.SegmentReadState;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.util.StringHelper;
+import org.apache.lucene.util.Version;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link ParquetSegmentLayout} (task 4.3): attribute-based resolution, the
+ * directory-scan fallback (including the sibling {@code parquet/} directory), and the
+ * "no Parquet file" case.
+ */
+public class ParquetSegmentLayoutTests extends OpenSearchTestCase {
+
+    public void testResolveByAttribute() throws Exception {
+        Path dir = createTempDir();
+        Path parquet = dir.resolve("_parquet_file_generation_1.parquet");
+        Files.write(parquet, new byte[] { 1, 2, 3 });
+
+        try (FSDirectory directory = FSDirectory.open(dir)) {
+            SegmentReadState state = newState(directory, Map.of(ParquetSegmentLayout.PARQUET_FILE_ATTRIBUTE, parquet.toString()));
+            Path resolved = ParquetSegmentLayout.resolve(state);
+            assertNotNull(resolved);
+            assertEquals(parquet.toString(), resolved.toString());
+        }
+    }
+
+    public void testResolveBySiblingParquetDirectory() throws Exception {
+        Path dir = createTempDir();
+        Path parquetDir = dir.resolve("parquet");
+        Files.createDirectories(parquetDir);
+        Path parquet = parquetDir.resolve("_parquet_file_generation_a.parquet");
+        Files.write(parquet, new byte[] { 1 });
+
+        try (FSDirectory directory = FSDirectory.open(dir)) {
+            SegmentReadState state = newState(directory, Map.of());
+            Path resolved = ParquetSegmentLayout.resolve(state);
+            assertNotNull(resolved);
+            assertEquals(parquet.getFileName().toString(), resolved.getFileName().toString());
+            assertTrue(resolved.toString().endsWith("parquet/_parquet_file_generation_a.parquet"));
+        }
+    }
+
+    public void testResolveByDirectoryScan() throws Exception {
+        Path dir = createTempDir();
+        Path parquet = dir.resolve("segment_data.parquet");
+        Files.write(parquet, new byte[] { 9 });
+
+        try (FSDirectory directory = FSDirectory.open(dir)) {
+            SegmentReadState state = newState(directory, Map.of());
+            Path resolved = ParquetSegmentLayout.resolve(state);
+            assertNotNull(resolved);
+            assertEquals("segment_data.parquet", resolved.getFileName().toString());
+        }
+    }
+
+    public void testResolveReturnsNullWhenNoParquetFile() throws Exception {
+        Path dir = createTempDir();
+        try (FSDirectory directory = FSDirectory.open(dir)) {
+            SegmentReadState state = newState(directory, Map.of());
+            assertNull(ParquetSegmentLayout.resolve(state));
+        }
+    }
+
+    public void testResolveReturnsNullWhenAttributePathMissing() throws Exception {
+        Path dir = createTempDir();
+        try (FSDirectory directory = FSDirectory.open(dir)) {
+            SegmentReadState state = newState(
+                directory,
+                Map.of(ParquetSegmentLayout.PARQUET_FILE_ATTRIBUTE, dir.resolve("does_not_exist.parquet").toString())
+            );
+            assertNull(ParquetSegmentLayout.resolve(state));
+        }
+    }
+
+    private static SegmentReadState newState(FSDirectory directory, Map<String, String> attributes) {
+        SegmentInfo si = new SegmentInfo(
+            directory,
+            Version.LATEST,
+            Version.LATEST,
+            "_0",
+            3,
+            false,
+            false,
+            Codec.getDefault(),
+            Map.of(),
+            StringHelper.randomId(),
+            attributes,
+            null
+        );
+        return new SegmentReadState(directory, si, FieldInfos.EMPTY, IOContext.DEFAULT);
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/BufferPoolTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/BufferPoolTests.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Unit tests for {@link BufferPool} (task 3.4): per-role reuse, monotonic grow, distinct
+ * roles, and post-close rejection.
+ */
+public class BufferPoolTests extends OpenSearchTestCase {
+
+    public void testSameRoleReusedWhenLargeEnough() {
+        try (BufferPool pool = new BufferPool()) {
+            MemorySegment a = pool.bytes("scratch", 128);
+            MemorySegment b = pool.bytes("scratch", 64); // smaller request — must reuse
+            assertSame("smaller request should reuse the same backing segment", a, b);
+            assertEquals(1, pool.slotCount());
+        }
+    }
+
+    public void testRoleGrowsMonotonically() {
+        try (BufferPool pool = new BufferPool()) {
+            MemorySegment small = pool.bytes("scratch", 64);
+            assertTrue(small.byteSize() >= 64);
+            MemorySegment grown = pool.bytes("scratch", 4096); // larger — must grow
+            assertTrue("grown segment must be at least the requested size", grown.byteSize() >= 4096);
+            assertNotSame("growing should replace the backing segment", small, grown);
+            // After growing, a smaller request reuses the grown (larger) segment.
+            MemorySegment reused = pool.bytes("scratch", 100);
+            assertSame(grown, reused);
+        }
+    }
+
+    public void testDistinctRolesAreIndependent() {
+        try (BufferPool pool = new BufferPool()) {
+            MemorySegment values = pool.longs("values", 10);
+            MemorySegment presence = pool.longs("presence", 4);
+            MemorySegment offsets = pool.ints("offsets", 11);
+            assertNotSame(values, presence);
+            assertNotSame(values, offsets);
+            assertNotSame(presence, offsets);
+            assertEquals(3, pool.slotCount());
+            // Re-fetching a role returns its own segment, unaffected by other roles.
+            assertSame(values, pool.longs("values", 10));
+        }
+    }
+
+    public void testLongsAndIntsSizing() {
+        try (BufferPool pool = new BufferPool()) {
+            assertTrue(pool.longs("a", 8).byteSize() >= 8 * Long.BYTES);
+            assertTrue(pool.ints("b", 16).byteSize() >= 16 * Integer.BYTES);
+            assertTrue("zero count still yields a usable segment", pool.longs("c", 0).byteSize() >= Long.BYTES);
+        }
+    }
+
+    public void testUseAfterCloseThrows() {
+        BufferPool pool = new BufferPool();
+        pool.bytes("scratch", 16);
+        pool.close();
+        expectThrows(IllegalStateException.class, () -> pool.bytes("scratch", 16));
+        // close is idempotent
+        pool.close();
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/CacheStructuresTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/CacheStructuresTests.java
@@ -1,0 +1,199 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+/**
+ * Unit tests for the layered-cache structures (task 3.4): {@link ColumnPageIndex} binary
+ * search + all-nulls detection (Layer 3/4), {@link PageCache} presence bit-test (Layer 2),
+ * and {@link BufferPool} slot reuse/growth (Layer 5). These are pure-Java and do not require
+ * the native library.
+ */
+public class CacheStructuresTests extends OpenSearchTestCase {
+
+    // ── ColumnPageIndex: pageForRow binary search across page boundaries ──
+
+    public void testPageForRowAcrossBoundaries() {
+        // 3 pages: rows [0,4), [4,10), [10,15). totalRows = 15.
+        ColumnPageIndex idx = new ColumnPageIndex(
+            new long[] { 0, 4, 10 },
+            new long[] { 0, 0, 0 },
+            new int[] { 0, 0, 0 },
+            new long[] { -1, -1, -1 },
+            new long[] { 0, 0, 0 },
+            new long[] { 0, 0, 0 },
+            15
+        );
+        assertEquals(3, idx.pageCount());
+
+        // First page [0,4)
+        assertEquals(0, idx.pageForRow(0));
+        assertEquals(0, idx.pageForRow(3));
+        // Boundary into second page
+        assertEquals(1, idx.pageForRow(4));
+        assertEquals(1, idx.pageForRow(9));
+        // Boundary into third page
+        assertEquals(2, idx.pageForRow(10));
+        assertEquals(2, idx.pageForRow(14));
+
+        // Out of range
+        assertEquals(-1, idx.pageForRow(-1));
+        assertEquals(-1, idx.pageForRow(15));
+        assertEquals(-1, idx.pageForRow(100));
+    }
+
+    public void testNumRowsOfIncludingLastPage() {
+        ColumnPageIndex idx = new ColumnPageIndex(
+            new long[] { 0, 4, 10 },
+            new long[] { 0, 0, 0 },
+            new int[] { 0, 0, 0 },
+            new long[] { -1, -1, -1 },
+            new long[] { 0, 0, 0 },
+            new long[] { 0, 0, 0 },
+            15
+        );
+        assertEquals(4, idx.numRowsOf(0));
+        assertEquals(6, idx.numRowsOf(1));
+        assertEquals(5, idx.numRowsOf(2)); // last page derives length from totalRows
+    }
+
+    public void testSinglePageIndex() {
+        ColumnPageIndex idx = new ColumnPageIndex(
+            new long[] { 0 },
+            new long[] { 0 },
+            new int[] { 0 },
+            new long[] { -1 },
+            new long[] { 0 },
+            new long[] { 0 },
+            8
+        );
+        assertEquals(0, idx.pageForRow(0));
+        assertEquals(0, idx.pageForRow(7));
+        assertEquals(-1, idx.pageForRow(8));
+        assertEquals(8, idx.numRowsOf(0));
+    }
+
+    // ── ColumnPageIndex: Layer 4 all-nulls detection ──
+
+    public void testIsAllNulls() {
+        // page 0: [0,4) all null (nullCount == 4); page 1: [4,10) no nulls; page 2: [10,15) unknown.
+        ColumnPageIndex idx = new ColumnPageIndex(
+            new long[] { 0, 4, 10 },
+            new long[] { 0, 0, 0 },
+            new int[] { 0, 0, 0 },
+            new long[] { 4, 0, -1 },
+            new long[] { 0, 0, 0 },
+            new long[] { 0, 0, 0 },
+            15
+        );
+        assertTrue("page 0 is entirely null", idx.isAllNulls(0));
+        assertFalse("page 1 has no nulls", idx.isAllNulls(1));
+        assertFalse("page 2 null count unknown -> not skippable", idx.isAllNulls(2));
+    }
+
+    public void testParallelArrayLengthValidation() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new ColumnPageIndex(
+                new long[] { 0, 4 },
+                new long[] { 0 },
+                new int[] { 0 },
+                new long[] { 0 },
+                new long[] { 0 },
+                new long[] { 0 },
+                4
+            )
+        );
+    }
+
+    // ── PageCache: Layer 2 presence bit-test + value lookup ──
+
+    public void testPresenceBitTestAndValueLookup() {
+        PageCache pc = new PageCache();
+        pc.firstRow = 4;
+        pc.lastRow = 9; // 6 rows
+        pc.values = new long[] { 40, 0, 60, 70, 0, 90 };
+        // present rows (relative): 0,2,3,5 -> bits 0b101101 = 45
+        pc.presenceBits = new long[] { 0b101101L };
+
+        assertEquals(6, pc.rowCount());
+        assertTrue(pc.contains(4));
+        assertTrue(pc.contains(9));
+        assertFalse(pc.contains(3));
+        assertFalse(pc.contains(10));
+
+        assertTrue(pc.isPresent(4)); // rel 0
+        assertFalse(pc.isPresent(5)); // rel 1
+        assertTrue(pc.isPresent(6)); // rel 2
+        assertTrue(pc.isPresent(7)); // rel 3
+        assertFalse(pc.isPresent(8)); // rel 4
+        assertTrue(pc.isPresent(9)); // rel 5
+
+        assertEquals(40L, pc.valueAt(4));
+        assertEquals(60L, pc.valueAt(6));
+        assertEquals(90L, pc.valueAt(9));
+    }
+
+    public void testPresenceBitTestAcrossWordBoundary() {
+        PageCache pc = new PageCache();
+        pc.firstRow = 0;
+        pc.lastRow = 127; // 128 rows -> 2 presence words
+        pc.presenceBits = new long[2];
+        // Mark rows 63 and 64 present (straddling the 64-bit word boundary).
+        pc.presenceBits[0] = 1L << 63;
+        pc.presenceBits[1] = 1L;
+
+        assertFalse(pc.isPresent(62));
+        assertTrue(pc.isPresent(63));
+        assertTrue(pc.isPresent(64));
+        assertFalse(pc.isPresent(65));
+    }
+
+    // ── BufferPool: Layer 5 slot reuse + monotonic growth ──
+
+    public void testBufferPoolReusesSlotWhenSizeFits() {
+        try (BufferPool pool = new BufferPool()) {
+            MemorySegment a = pool.longs("slot", 8);
+            MemorySegment b = pool.longs("slot", 4); // smaller -> same backing segment
+            assertSame("a smaller request must reuse the same backing segment", a, b);
+        }
+    }
+
+    public void testBufferPoolGrowsSlotMonotonically() {
+        try (BufferPool pool = new BufferPool()) {
+            MemorySegment small = pool.longs("slot", 2);
+            long smallSize = small.byteSize();
+            MemorySegment large = pool.longs("slot", 1000); // forces growth
+            assertTrue("grown segment must be larger", large.byteSize() > smallSize);
+            assertTrue("grown segment must hold the requested size", large.byteSize() >= 1000 * ValueLayout.JAVA_LONG.byteSize());
+
+            // A subsequent smaller request reuses the grown segment (no shrink).
+            MemorySegment reused = pool.longs("slot", 2);
+            assertSame(large, reused);
+        }
+    }
+
+    public void testBufferPoolDistinctSlotsAreIndependent() {
+        try (BufferPool pool = new BufferPool()) {
+            MemorySegment a = pool.longOut("present");
+            MemorySegment b = pool.longOut("len");
+            assertNotSame("distinct slot names must yield distinct segments", a, b);
+        }
+    }
+
+    public void testBufferPoolRejectsUseAfterClose() {
+        BufferPool pool = new BufferPool();
+        pool.close();
+        expectThrows(IllegalStateException.class, () -> pool.longs("slot", 1));
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/CacheStructuresTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/CacheStructuresTests.java
@@ -10,6 +10,7 @@ package org.opensearch.parquet.codec.cache;
 
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 
@@ -122,7 +123,10 @@ public class CacheStructuresTests extends OpenSearchTestCase {
         PageCache pc = new PageCache();
         pc.firstRow = 4;
         pc.lastRow = 9; // 6 rows
-        pc.values = new long[] { 40, 0, 60, 70, 0, 90 };
+        long[] vals = { 40, 0, 60, 70, 0, 90 };
+        MemorySegment valueSeg = Arena.ofAuto().allocate((long) vals.length * ValueLayout.JAVA_LONG.byteSize());
+        MemorySegment.copy(vals, 0, valueSeg, ValueLayout.JAVA_LONG, 0, vals.length);
+        pc.values = valueSeg;
         // present rows (relative): 0,2,3,5 -> bits 0b101101 = 45
         pc.presenceBits = new long[] { 0b101101L };
 

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/ColumnPageIndexTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/ColumnPageIndexTests.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link ColumnPageIndex} (task 3.4): page-for-row binary search across page
+ * boundaries, row-count derivation, and the Layer-4 all-nulls detection.
+ */
+public class ColumnPageIndexTests extends OpenSearchTestCase {
+
+    /** Three pages: rows [0,4), [4,8), [8,10) — total 10 rows. */
+    private ColumnPageIndex threePage() {
+        return new ColumnPageIndex(
+            new long[] { 0, 4, 8 },          // firstRowOf
+            new long[] { 0, 100, 200 },      // fileOffsetOf
+            new int[] { 50, 50, 25 },        // compressedSizeOf
+            new long[] { 0, 0, 0 },          // nullCountOf
+            new long[] { 0, 0, 0 },          // minOf
+            new long[] { 0, 0, 0 },          // maxOf
+            10                               // totalRows
+        );
+    }
+
+    public void testPageCountAndRowsPerPage() {
+        ColumnPageIndex idx = threePage();
+        assertEquals(3, idx.pageCount());
+        assertEquals(4L, idx.numRowsOf(0));
+        assertEquals(4L, idx.numRowsOf(1));
+        assertEquals(2L, idx.numRowsOf(2)); // last page: totalRows - firstRow = 10 - 8
+        assertEquals(10L, idx.totalRows());
+    }
+
+    public void testPageForRowAcrossBoundaries() {
+        ColumnPageIndex idx = threePage();
+        // page 0: rows 0..3
+        assertEquals(0, idx.pageForRow(0));
+        assertEquals(0, idx.pageForRow(3));
+        // page 1: rows 4..7 (boundary at 4)
+        assertEquals(1, idx.pageForRow(4));
+        assertEquals(1, idx.pageForRow(7));
+        // page 2: rows 8..9 (boundary at 8)
+        assertEquals(2, idx.pageForRow(8));
+        assertEquals(2, idx.pageForRow(9));
+    }
+
+    public void testPageForRowOutOfRange() {
+        ColumnPageIndex idx = threePage();
+        assertEquals(-1, idx.pageForRow(-1));
+        assertEquals(-1, idx.pageForRow(10));
+        assertEquals(-1, idx.pageForRow(99));
+    }
+
+    public void testSinglePage() {
+        ColumnPageIndex idx = new ColumnPageIndex(
+            new long[] { 0 },
+            new long[] { 0 },
+            new int[] { 10 },
+            new long[] { -1 },
+            new long[] { 0 },
+            new long[] { 0 },
+            5
+        );
+        assertEquals(1, idx.pageCount());
+        assertEquals(5L, idx.numRowsOf(0));
+        for (long r = 0; r < 5; r++) {
+            assertEquals("row " + r, 0, idx.pageForRow(r));
+        }
+        assertEquals(-1, idx.pageForRow(5));
+    }
+
+    public void testIsAllNulls() {
+        ColumnPageIndex idx = new ColumnPageIndex(
+            new long[] { 0, 4, 8 },
+            new long[] { 0, 0, 0 },
+            new int[] { 0, 0, 0 },
+            new long[] { 4, 0, -1 },         // page0 all-null (4 of 4), page1 none, page2 unknown
+            new long[] { 0, 0, 0 },
+            new long[] { 0, 0, 0 },
+            10
+        );
+        assertTrue("page 0 (nullCount==rows) should be all-nulls", idx.isAllNulls(0));
+        assertFalse("page 1 (nullCount 0) should not be all-nulls", idx.isAllNulls(1));
+        assertFalse("page 2 (nullCount unknown) should not be all-nulls", idx.isAllNulls(2));
+    }
+
+    public void testMismatchedArrayLengthsRejected() {
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new ColumnPageIndex(
+                new long[] { 0, 4 },
+                new long[] { 0 }, // wrong length
+                new int[] { 0, 0 },
+                new long[] { 0, 0 },
+                new long[] { 0, 0 },
+                new long[] { 0, 0 },
+                8
+            )
+        );
+    }
+
+    public void testManyPagesBinarySearch() {
+        int pages = 1000;
+        long[] firstRowOf = new long[pages];
+        long[] zerosL = new long[pages];
+        int[] zerosI = new int[pages];
+        for (int p = 0; p < pages; p++) {
+            firstRowOf[p] = (long) p * 8;
+        }
+        ColumnPageIndex idx = new ColumnPageIndex(
+            firstRowOf,
+            zerosL,
+            zerosI,
+            zerosL.clone(),
+            zerosL.clone(),
+            zerosL.clone(),
+            (long) pages * 8
+        );
+        // Probe a random row in every page and confirm the binary search lands on it.
+        for (int p = 0; p < pages; p++) {
+            long row = (long) p * 8 + randomIntBetween(0, 7);
+            assertEquals("row " + row, p, idx.pageForRow(row));
+        }
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/PageCacheTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/PageCacheTests.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.parquet.codec.cache;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link PageCache} (task 3.4): presence bit-test correctness across word
+ * boundaries and primitive value lookup by global row.
+ */
+public class PageCacheTests extends OpenSearchTestCase {
+
+    public void testPresenceBitTestWithinAndAcrossWords() {
+        PageCache pc = new PageCache();
+        pc.firstRow = 100;
+        pc.lastRow = 199; // 100 rows
+        pc.values = new long[100];
+        // Mark even local indices present.
+        pc.presenceBits = new long[(100 + 63) >> 6];
+        for (int i = 0; i < 100; i++) {
+            if (i % 2 == 0) {
+                pc.presenceBits[i >> 6] |= (1L << (i & 63));
+            }
+            pc.values[i] = 1000 + i;
+        }
+
+        assertEquals(100, pc.rowCount());
+        for (long row = 100; row <= 199; row++) {
+            int local = (int) (row - 100);
+            boolean expectedPresent = local % 2 == 0;
+            assertEquals("row " + row, expectedPresent, pc.isPresent(row));
+            assertEquals("value at row " + row, 1000L + local, pc.valueAt(row));
+        }
+    }
+
+    public void testPresenceAcrossWord64Boundary() {
+        PageCache pc = new PageCache();
+        pc.firstRow = 0;
+        pc.lastRow = 127; // exactly two 64-bit words
+        pc.presenceBits = new long[2];
+        // Set local indices 63 and 64 (the word boundary).
+        pc.presenceBits[63 >> 6] |= (1L << (63 & 63));
+        pc.presenceBits[64 >> 6] |= (1L << (64 & 63));
+
+        assertFalse(pc.isPresent(62));
+        assertTrue(pc.isPresent(63));
+        assertTrue(pc.isPresent(64));
+        assertFalse(pc.isPresent(65));
+    }
+
+    public void testContains() {
+        PageCache pc = new PageCache();
+        pc.firstRow = 10;
+        pc.lastRow = 20;
+        assertFalse(pc.contains(9));
+        assertTrue(pc.contains(10));
+        assertTrue(pc.contains(15));
+        assertTrue(pc.contains(20));
+        assertFalse(pc.contains(21));
+    }
+}

--- a/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/PageCacheTests.java
+++ b/sandbox/plugins/parquet-data-format/src/test/java/org/opensearch/parquet/codec/cache/PageCacheTests.java
@@ -10,6 +10,10 @@ package org.opensearch.parquet.codec.cache;
 
 import org.opensearch.test.OpenSearchTestCase;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
 /**
  * Unit tests for {@link PageCache} (task 3.4): presence bit-test correctness across word
  * boundaries and primitive value lookup by global row.
@@ -20,14 +24,15 @@ public class PageCacheTests extends OpenSearchTestCase {
         PageCache pc = new PageCache();
         pc.firstRow = 100;
         pc.lastRow = 199; // 100 rows
-        pc.values = new long[100];
+        MemorySegment values = Arena.ofAuto().allocate(100L * ValueLayout.JAVA_LONG.byteSize());
+        pc.values = values;
         // Mark even local indices present.
         pc.presenceBits = new long[(100 + 63) >> 6];
         for (int i = 0; i < 100; i++) {
             if (i % 2 == 0) {
                 pc.presenceBits[i >> 6] |= (1L << (i & 63));
             }
-            pc.values[i] = 1000 + i;
+            values.setAtIndex(ValueLayout.JAVA_LONG, i, 1000 + i);
         }
 
         assertEquals(100, pc.rowCount());

--- a/sandbox/qa/analytics-engine-rest/build.gradle
+++ b/sandbox/qa/analytics-engine-rest/build.gradle
@@ -104,6 +104,11 @@ def configureAnalyticsCluster = { cluster ->
     // analytics-engine path (bypassing the per-index lookup that doesn't handle aliases,
     // wildcards, or comma-lists).
     cluster.setting 'cluster.pluggable.dataformat', 'composite'
+    // Enable liquid cache feature flag
+    cluster.systemProperty 'opensearch.experimental.feature.liquid_cache.enabled', 'true'
+
+    // Liquid cache dir must be on real filesystem (not tmpfs) for io-uring
+    cluster.setting 'datafusion.liquid_cache.cache_dir', "${buildDir}/liquid_cache"
 
     // analytics-engine requires the streaming transport — fragment dispatch is streaming-only.
     cluster.systemProperty 'opensearch.experimental.feature.transport.stream.enabled', 'true'

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LiquidCacheBenchmarkIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LiquidCacheBenchmarkIT.java
@@ -1,0 +1,196 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark comparing query latency with and without Liquid Cache on a
+ * scaled-down ClickBench-like dataset (~100K rows).
+ *
+ * Run with:
+ * ./gradlew :sandbox:qa:analytics-engine-rest:integTest \
+ *   --tests "org.opensearch.analytics.qa.LiquidCacheBenchmarkIT" \
+ *   -Dsandbox.enabled=true
+ *
+ * Results are printed to stdout — compare "LC OFF" vs "LC ON" latencies.
+ */
+@SuppressWarnings("unchecked")
+public class LiquidCacheBenchmarkIT extends AnalyticsRestTestCase {
+
+    private static final Logger logger = LogManager.getLogger(LiquidCacheBenchmarkIT.class);
+    private static final String INDEX_NAME = "liquid_cache_bench";
+    private static final int NUM_DOCS = 100_000;
+    private static final int BULK_BATCH_SIZE = 5000;
+    private static final int WARMUP_ITERATIONS = 3;
+    private static final int MEASURE_ITERATIONS = 10;
+
+    private static final String[] QUERIES = {
+        // Q1: COUNT with equality filter (keyword)
+        "source=" + INDEX_NAME + " | where status = '200' | stats count() as cnt",
+        // Q2: Aggregation with range filter (numeric)
+        "source=" + INDEX_NAME + " | where response_time > 500 | stats avg(response_time) as avg_rt",
+        // Q3: GROUP BY low-cardinality keyword
+        "source=" + INDEX_NAME + " | stats count() as cnt by status",
+        // Q4: GROUP BY + range filter (time-range pattern)
+        "source=" + INDEX_NAME + " | where event_time > 1700000000000 | stats count() as cnt by region",
+        // Q5: Multi-column aggregation
+        "source=" + INDEX_NAME + " | where status = '500' | stats avg(response_time) as avg_rt, max(response_time) as max_rt",
+        // Q6: High selectivity filter + count
+        "source=" + INDEX_NAME + " | where user_id = 'user_42' | stats count() as cnt",
+    };
+
+    public void testLiquidCacheBenchmark() throws Exception {
+        setupIndex();
+
+        logger.info("=== Liquid Cache Benchmark: {} docs, {} queries ===", NUM_DOCS, QUERIES.length);
+
+        // Phase 1: LC OFF — baseline
+        updateSetting("datafusion.liquid_cache.enabled", "false");
+        long[] baselineLatencies = runBenchmark("LC OFF");
+
+        // Phase 2: LC ON — first run (cold cache, populates cache)
+        updateSetting("datafusion.liquid_cache.enabled", "true");
+        long[] coldCacheLatencies = runBenchmark("LC ON (cold)");
+
+        // Phase 3: LC ON — second run (warm cache, should be faster)
+        long[] warmCacheLatencies = runBenchmark("LC ON (warm)");
+
+        // Report
+        logger.info("=== RESULTS (median of {} iterations, ms) ===", MEASURE_ITERATIONS);
+        logger.info(String.format("%-60s %10s %10s %10s %10s", "Query", "Baseline", "Cold", "Warm", "Speedup"));
+        for (int i = 0; i < QUERIES.length; i++) {
+            String q = QUERIES[i].length() > 58 ? QUERIES[i].substring(0, 58) + ".." : QUERIES[i];
+            double speedup = baselineLatencies[i] > 0 ? (double) baselineLatencies[i] / warmCacheLatencies[i] : 0;
+            logger.info(String.format("%-60s %8dms %8dms %8dms %8.1fx", q, baselineLatencies[i], coldCacheLatencies[i], warmCacheLatencies[i], speedup));
+        }
+    }
+
+    private long[] runBenchmark(String label) throws Exception {
+        long[] medians = new long[QUERIES.length];
+        for (int q = 0; q < QUERIES.length; q++) {
+            // Warmup
+            for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+                executePplRaw(QUERIES[q]);
+            }
+            // Measure
+            List<Long> latencies = new ArrayList<>();
+            for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+                long start = System.nanoTime();
+                executePplRaw(QUERIES[q]);
+                long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+                latencies.add(elapsed);
+            }
+            latencies.sort(Long::compareTo);
+            medians[q] = latencies.get(latencies.size() / 2);
+            logger.info("[{}] Q{}: median={}ms, min={}ms, max={}ms",
+                label, q + 1, medians[q], latencies.get(0), latencies.get(latencies.size() - 1));
+        }
+        return medians;
+    }
+
+    private void setupIndex() throws Exception {
+        deleteIndexIfExists(INDEX_NAME);
+        createIndex();
+        ingestData();
+        flush();
+        logger.info("Index created with {} docs", NUM_DOCS);
+    }
+
+    private void createIndex() throws Exception {
+        Request request = new Request("PUT", "/" + INDEX_NAME);
+        request.setJsonEntity("{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 1,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"refresh_interval\": \"-1\","
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"event_time\": {\"type\": \"long\"},"
+            + "    \"status\": {\"type\": \"keyword\"},"
+            + "    \"region\": {\"type\": \"keyword\"},"
+            + "    \"user_id\": {\"type\": \"keyword\"},"
+            + "    \"response_time\": {\"type\": \"integer\"},"
+            + "    \"bytes_sent\": {\"type\": \"long\"},"
+            + "    \"url\": {\"type\": \"keyword\"}"
+            + "  }"
+            + "}"
+            + "}");
+        assertEquals(200, client().performRequest(request).getStatusLine().getStatusCode());
+    }
+
+    private void ingestData() throws Exception {
+        Random rng = new Random(42); // deterministic seed
+        String[] statuses = {"200", "301", "404", "500"};
+        String[] regions = {"us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"};
+
+        int ingested = 0;
+        while (ingested < NUM_DOCS) {
+            int batchSize = Math.min(BULK_BATCH_SIZE, NUM_DOCS - ingested);
+            StringBuilder bulk = new StringBuilder();
+            for (int i = 0; i < batchSize; i++) {
+                bulk.append("{\"index\":{}}\n");
+                bulk.append("{")
+                    .append("\"event_time\":").append(1700000000000L + rng.nextInt(86400000)).append(",")
+                    .append("\"status\":\"").append(statuses[rng.nextInt(statuses.length)]).append("\",")
+                    .append("\"region\":\"").append(regions[rng.nextInt(regions.length)]).append("\",")
+                    .append("\"user_id\":\"user_").append(rng.nextInt(10000)).append("\",")
+                    .append("\"response_time\":").append(50 + rng.nextInt(2000)).append(",")
+                    .append("\"bytes_sent\":").append(100 + rng.nextInt(50000)).append(",")
+                    .append("\"url\":\"/api/v").append(rng.nextInt(3) + 1).append("/resource/").append(rng.nextInt(1000)).append("\"")
+                    .append("}\n");
+            }
+            Request request = new Request("POST", "/" + INDEX_NAME + "/_bulk");
+            request.setJsonEntity(bulk.toString());
+            Response response = client().performRequest(request);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            ingested += batchSize;
+            if (ingested % 20000 == 0) {
+                logger.info("Ingested {}/{} docs", ingested, NUM_DOCS);
+            }
+        }
+    }
+
+    private void flush() throws Exception {
+        client().performRequest(new Request("POST", "/" + INDEX_NAME + "/_refresh"));
+        client().performRequest(new Request("POST", "/" + INDEX_NAME + "/_flush?force=true"));
+    }
+
+    private void executePplRaw(String query) throws Exception {
+        Request request = new Request("POST", "/_plugins/_ppl");
+        request.setJsonEntity("{\"query\":\"" + query + "\"}");
+        client().performRequest(request);
+    }
+
+    private void updateSetting(String key, String value) throws Exception {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity("{\"transient\":{\"" + key + "\":\"" + value + "\"}}");
+        client().performRequest(request);
+    }
+
+    private void deleteIndexIfExists(String name) throws Exception {
+        try {
+            client().performRequest(new Request("DELETE", "/" + name));
+        } catch (Exception e) {
+            // ignore — index may not exist
+        }
+    }
+}

--- a/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LiquidCacheIT.java
+++ b/sandbox/qa/analytics-engine-rest/src/test/java/org/opensearch/analytics/qa/LiquidCacheIT.java
@@ -1,0 +1,192 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.qa;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration tests for Liquid Cache functionality within the analytics engine.
+ * <p>
+ * Validates:
+ * <ul>
+ *   <li>Composite parquet index creation and data ingestion</li>
+ *   <li>PPL query execution through DataFusion with numeric predicates</li>
+ *   <li>Dynamic enable/disable of liquid cache via cluster settings</li>
+ *   <li>Dynamic resize of memory and disk budget at runtime</li>
+ *   <li>Query correctness across all cache states</li>
+ * </ul>
+ * <p>
+ * Requires feature flags:
+ * {@code opensearch.experimental.feature.pluggable.dataformat.enabled=true},
+ * {@code opensearch.experimental.feature.liquid_cache.enabled=true}
+ */
+@SuppressWarnings("unchecked")
+public class LiquidCacheIT extends AnalyticsRestTestCase {
+
+    private static final Logger logger = LogManager.getLogger(LiquidCacheIT.class);
+    private static final String INDEX_NAME = "liquid_cache_integ";
+    private static final String PPL_ENDPOINT = "/_analytics/ppl";
+    private static final long EXPECTED_SUM_AGE_GT_25 = 300000L;
+
+    /**
+     * End-to-end test: index lifecycle, query execution, dynamic toggle, and budget resize.
+     */
+    public void testLiquidCacheEndToEnd() throws Exception {
+        setupIndex();
+
+        verifyQueryReturnsExpectedResult();
+        verifyDynamicDisableAndReenable();
+        verifyDynamicBudgetResize();
+    }
+
+    private void verifyQueryReturnsExpectedResult() throws Exception {
+        logger.info("Executing PPL query with numeric predicate (age > 25)");
+        long latency = executePplAndAssert(
+            "source=" + INDEX_NAME + " | where age > 25 | stats sum(salary) as total",
+            EXPECTED_SUM_AGE_GT_25
+        );
+        logger.info("Query latency: {}ms", latency);
+    }
+
+    private void verifyDynamicDisableAndReenable() throws Exception {
+        updateSetting("datafusion.liquid_cache.enabled", "false");
+        logger.info("Liquid cache disabled via cluster settings");
+
+        long disabledLatency = executePplAndAssert(
+            "source=" + INDEX_NAME + " | where age > 25 | stats sum(salary) as total",
+            EXPECTED_SUM_AGE_GT_25
+        );
+        logger.info("Query latency (LC disabled): {}ms", disabledLatency);
+
+        updateSetting("datafusion.liquid_cache.enabled", "true");
+        logger.info("Liquid cache re-enabled via cluster settings");
+
+        long reenabledLatency = executePplAndAssert(
+            "source=" + INDEX_NAME + " | where age > 25 | stats sum(salary) as total",
+            EXPECTED_SUM_AGE_GT_25
+        );
+        logger.info("Query latency (LC re-enabled): {}ms", reenabledLatency);
+    }
+
+    private void verifyDynamicBudgetResize() throws Exception {
+        long newMemory = 512L * 1024 * 1024;
+        long newDisk = 5L * 1024 * 1024 * 1024;
+
+        updateSetting("datafusion.liquid_cache.size_bytes", String.valueOf(newMemory));
+        updateSetting("datafusion.liquid_cache.max_disk_bytes", String.valueOf(newDisk));
+
+        Response response = client().performRequest(new Request("GET", "/_cluster/settings?flat_settings=true&include_defaults=false"));
+        Map<String, Object> settings = entityAsMap(response);
+        Map<String, Object> transient_ = (Map<String, Object>) settings.get("transient");
+
+        assertEquals("Memory budget not updated", String.valueOf(newMemory), transient_.get("datafusion.liquid_cache.size_bytes"));
+        assertEquals("Disk budget not updated", String.valueOf(newDisk), transient_.get("datafusion.liquid_cache.max_disk_bytes"));
+        logger.info("Budget resize verified: memory={}MB, disk={}GB", newMemory / (1024 * 1024), newDisk / (1024 * 1024 * 1024));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private void setupIndex() throws Exception {
+        deleteIndexIfExists(INDEX_NAME);
+        createCompositeParquetIndex();
+        bulkIngestTestData();
+        flushAndForceMerge();
+        verifyParquetFormat();
+    }
+
+    private void createCompositeParquetIndex() throws Exception {
+        Request request = new Request("PUT", "/" + INDEX_NAME);
+        request.setJsonEntity("{"
+            + "\"settings\": {"
+            + "  \"number_of_shards\": 1,"
+            + "  \"number_of_replicas\": 0,"
+            + "  \"index.pluggable.dataformat.enabled\": true,"
+            + "  \"index.pluggable.dataformat\": \"composite\","
+            + "  \"index.composite.primary_data_format\": \"parquet\""
+            + "},"
+            + "\"mappings\": {"
+            + "  \"properties\": {"
+            + "    \"name\": {\"type\": \"keyword\"},"
+            + "    \"age\": {\"type\": \"integer\"},"
+            + "    \"salary\": {\"type\": \"long\"}"
+            + "  }"
+            + "}"
+            + "}");
+        assertEquals(200, client().performRequest(request).getStatusLine().getStatusCode());
+    }
+
+    private void bulkIngestTestData() throws Exception {
+        Request request = new Request("POST", "/" + INDEX_NAME + "/_bulk");
+        request.addParameter("refresh", "true");
+        request.setJsonEntity(
+            "{\"index\":{}}\n{\"name\":\"Alice\",\"age\":30,\"salary\":75000}\n"
+            + "{\"index\":{}}\n{\"name\":\"Bob\",\"age\":25,\"salary\":60000}\n"
+            + "{\"index\":{}}\n{\"name\":\"Charlie\",\"age\":35,\"salary\":90000}\n"
+            + "{\"index\":{}}\n{\"name\":\"Diana\",\"age\":28,\"salary\":70000}\n"
+            + "{\"index\":{}}\n{\"name\":\"Eve\",\"age\":35,\"salary\":65000}\n"
+        );
+        assertEquals(200, client().performRequest(request).getStatusLine().getStatusCode());
+    }
+
+    private void flushAndForceMerge() throws Exception {
+        client().performRequest(new Request("POST", "/" + INDEX_NAME + "/_flush?force=true"));
+        Request merge = new Request("POST", "/" + INDEX_NAME + "/_forcemerge");
+        merge.addParameter("max_num_segments", "1");
+        client().performRequest(merge);
+        Thread.sleep(5000);
+    }
+
+    private void verifyParquetFormat() throws Exception {
+        Response response = client().performRequest(new Request("GET", "/" + INDEX_NAME + "/_settings?flat_settings=true"));
+        Map<String, Object> settings = entityAsMap(response);
+        Map<String, Object> indexSettings = (Map<String, Object>) ((Map<String, Object>) settings.get(INDEX_NAME)).get("settings");
+        assertEquals("parquet", indexSettings.get("index.composite.primary_data_format"));
+    }
+
+    private long executePplAndAssert(String pplQuery, long expectedValue) throws Exception {
+        long start = System.currentTimeMillis();
+        Request request = new Request("POST", PPL_ENDPOINT);
+        request.setJsonEntity("{\"query\": \"" + pplQuery + "\"}");
+        Response response = client().performRequest(request);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        Map<String, Object> body = entityAsMap(response);
+        logger.info("PPL response: {}", body);
+        assertNotNull("Response body should not be null", body);
+
+        @SuppressWarnings("unchecked")
+        List<List<Object>> rows = (List<List<Object>>) body.get("rows");
+        assertNotNull("Response should contain rows", rows);
+        assertFalse("Rows should not be empty", rows.isEmpty());
+        Number actual = (Number) rows.get(0).get(0);
+        assertEquals("Query result mismatch", expectedValue, actual.longValue());
+
+        return elapsed;
+    }
+
+    private void deleteIndexIfExists(String index) {
+        try {
+            client().performRequest(new Request("DELETE", "/" + index));
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void updateSetting(String key, String value) throws Exception {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity("{\"transient\":{\"" + key + "\":\"" + value + "\"}}");
+        assertEquals(200, client().performRequest(request).getStatusLine().getStatusCode());
+    }
+}

--- a/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
+++ b/server/src/main/java/org/opensearch/common/util/FeatureFlags.java
@@ -128,6 +128,16 @@ public class FeatureFlags {
     public static final Setting<Boolean> STREAM_TRANSPORT_SETTING = Setting.boolSetting(STREAM_TRANSPORT, false, Property.NodeScope);
 
     /**
+     * Gates the functionality of Liquid Cache for byte-level Parquet caching.
+     */
+    public static final String LIQUID_CACHE_EXPERIMENTAL_FLAG = FEATURE_FLAG_PREFIX + "liquid_cache.enabled";
+    public static final Setting<Boolean> LIQUID_CACHE_EXPERIMENTAL_SETTING = Setting.boolSetting(
+        LIQUID_CACHE_EXPERIMENTAL_FLAG,
+        false,
+        Property.NodeScope
+    );
+
+    /**
      * Underlying implementation for feature flags.
      * All settable feature flags are tracked here in FeatureFlagsImpl.featureFlags.
      * Contains all functionality across test and server use cases.
@@ -153,6 +163,7 @@ public class FeatureFlags {
                 put(STREAM_TRANSPORT_SETTING, STREAM_TRANSPORT_SETTING.getDefault(Settings.EMPTY));
                 put(CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_SETTING, CONTEXT_AWARE_MIGRATION_EXPERIMENTAL_SETTING.getDefault(Settings.EMPTY));
                 put(PLUGGABLE_DATAFORMAT_EXPERIMENTAL_SETTING, PLUGGABLE_DATAFORMAT_EXPERIMENTAL_SETTING.getDefault(Settings.EMPTY));
+                put(LIQUID_CACHE_EXPERIMENTAL_SETTING, LIQUID_CACHE_EXPERIMENTAL_SETTING.getDefault(Settings.EMPTY));
             }
         };
 

--- a/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/DataFormatAwareEngine.java
@@ -10,6 +10,7 @@ package org.opensearch.index.engine;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.ReferenceManager;
@@ -24,6 +25,7 @@ import org.opensearch.common.concurrent.GatedConditionalCloseable;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.logging.Loggers;
 import org.opensearch.common.lucene.Lucene;
+import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
 import org.opensearch.common.lucene.uid.Versions;
 import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.queue.DefaultLockableHolder;
@@ -66,6 +68,7 @@ import org.opensearch.index.engine.exec.FilesListener;
 import org.opensearch.index.engine.exec.IndexReaderProvider;
 import org.opensearch.index.engine.exec.Indexer;
 import org.opensearch.index.engine.exec.PrimaryTermFieldType;
+import org.opensearch.index.engine.exec.SearchableDirectoryReaderProvider;
 import org.opensearch.index.engine.exec.Segment;
 import org.opensearch.index.engine.exec.WriterFileSet;
 import org.opensearch.index.engine.exec.commit.Committer;
@@ -107,11 +110,13 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -122,6 +127,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static org.opensearch.index.engine.Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
@@ -2065,6 +2071,158 @@ public class DataFormatAwareEngine implements Indexer {
         } catch (Exception e) {
             snapshotRef.close();
             throw e;
+        }
+    }
+
+    /**
+     * Acquires a point-in-time {@link Engine.SearcherSupplier} built from this engine's Lucene-format
+     * {@link DirectoryReader}. This lets the standard {@code _search} → {@code QueryPhase} path reach
+     * composite-engine shards without {@link org.opensearch.index.shard.IndexShard} ever depending on
+     * the concrete engine type.
+     * <p>
+     * The searcher wraps only the secondary "lucene" format's reader and knows nothing of Parquet or
+     * DataFusion. Its single job is producing the matching docId set; that set becomes the backend's
+     * row filter in the aggregation phase.
+     * <p>
+     * Reference counting: the {@link GatedCloseable} returned by {@link #acquireReader()} holds the
+     * catalog snapshot and reader refs; {@code doClose()} releases them when the search context closes.
+     *
+     * @param wrapper a function applied to each acquired {@link Engine.Searcher} (e.g. reader wrapping)
+     * @param scope   the searcher scope (unused — composite engine has a single reader view)
+     * @return a searcher supplier whose {@code close()} releases the underlying reader resources
+     * @throws IllegalStateException if no Lucene-format reader is available for this composite index
+     */
+    @Override
+    public Engine.SearcherSupplier acquireSearcherSupplier(Function<Engine.Searcher, Engine.Searcher> wrapper, Engine.SearcherScope scope) {
+        ensureOpen();
+        final GatedCloseable<IndexReaderProvider.Reader> readerRef;
+        try {
+            readerRef = acquireReader();
+        } catch (IOException e) {
+            throw new EngineException(shardId, "failed to acquire reader for searcher", e);
+        }
+        try {
+            // Look up the lucene format's reader from the format-aware reader map.
+            // The reader object is opaque to the server module (it's a LuceneReader record from the
+            // analytics-backend-lucene plugin). We extract the DirectoryReader via reflection on the
+            // record's directoryReader() component accessor — this is stable API (record components
+            // cannot be renamed without breaking serialization).
+            DataFormat luceneFormat = engineConfig.getDataFormatRegistry().format("lucene");
+            Object luceneReaderObj = readerRef.get().reader(luceneFormat);
+            if (luceneReaderObj == null) {
+                IOUtils.closeWhileHandlingException(readerRef);
+                throw new IllegalStateException("No Lucene reader available for composite index " + shardId);
+            }
+            final DirectoryReader rawDirectoryReader = extractDirectoryReader(luceneReaderObj);
+            // Bind each Lucene leaf to its backing Parquet file by matching the leaf's file set
+            // against the catalog snapshot's per-segment Lucene file set, then stamping the resolved
+            // Parquet file path as a SegmentInfo attribute that the Parquet DocValues codec reads back.
+            // This is the authoritative resolution (correct for merged segments, where the per-segment
+            // writer_generation attribute is reset to 0 and a directory scan would pick the wrong file).
+            stampParquetDocValuesFiles(rawDirectoryReader, readerRef.get().catalogSnapshot());
+            // Wrap in an OpenSearchDirectoryReader so the standard searcher-wrapping path
+            // (IndexShard#wrapSearcher → IndexModule#setReaderWrapper) accepts it. That path rejects
+            // any reader that is not an OpenSearchDirectoryReader. Plugins (e.g. the Parquet DocValues
+            // codec) attach their per-field DocValues view via the registered reader wrapper.
+            final DirectoryReader directoryReader = OpenSearchDirectoryReader.wrap(rawDirectoryReader, shardId);
+            return new Engine.SearcherSupplier(wrapper) {
+                @Override
+                protected Engine.Searcher acquireSearcherInternal(String source) {
+                    return new Engine.Searcher(
+                        source,
+                        directoryReader,
+                        engineConfig.getSimilarity(),
+                        engineConfig.getQueryCache(),
+                        engineConfig.getQueryCachingPolicy(),
+                        () -> {}
+                    );
+                }
+
+                @Override
+                protected void doClose() {
+                    IOUtils.closeWhileHandlingException(readerRef);
+                }
+            };
+        } catch (Exception e) {
+            IOUtils.closeWhileHandlingException(readerRef);
+            if (e instanceof IllegalStateException) {
+                throw (IllegalStateException) e;
+            }
+            throw new EngineException(shardId, "failed to build searcher supplier from composite reader", e);
+        }
+    }
+
+    /**
+     * Extracts a {@link DirectoryReader} from the opaque format-specific reader object.
+     * The lucene format's reader is a record with a {@code directoryReader()} component accessor
+     * that returns a {@link DirectoryReader}. Since the server module cannot import the concrete
+     * record type (it lives in a sandbox plugin), we use reflection on the well-known accessor name.
+     */
+    private static DirectoryReader extractDirectoryReader(Object luceneReaderObj) {
+        if (luceneReaderObj instanceof DirectoryReader dr) {
+            return dr;
+        }
+        if (luceneReaderObj instanceof SearchableDirectoryReaderProvider searchable) {
+            return searchable.directoryReader();
+        }
+        throw new IllegalStateException(
+            "Lucene format reader " + luceneReaderObj.getClass().getName()
+                + " does not implement SearchableDirectoryReaderProvider; cannot build searcher"
+        );
+    }
+
+    /** SegmentInfo attribute key carrying the absolute Parquet file path backing a leaf's doc values.
+     *  Mirrors {@code ParquetSegmentLayout.PARQUET_FILE_ATTRIBUTE} in the parquet-data-format plugin
+     *  (kept as a string literal here to avoid a server→plugin dependency). */
+    private static final String PARQUET_DOCVALUES_FILE_ATTRIBUTE = "parquet.docvalues.file";
+
+    /**
+     * Binds each Lucene leaf of {@code directoryReader} to its backing Parquet file and stamps the
+     * resolved absolute path onto the leaf's {@link org.apache.lucene.index.SegmentInfo} via
+     * {@link PARQUET_DOCVALUES_FILE_ATTRIBUTE}, so the Parquet DocValues codec can read the right file
+     * without performing an (incorrect, for merged segments) directory scan.
+     *
+     * <p>Resolution matches the leaf's Lucene file set against each catalog {@link Segment}'s Lucene
+     * {@link WriterFileSet#files()} (the same correlation key {@code LuceneReaderManager} uses), then
+     * takes that segment's {@code "parquet"} {@link WriterFileSet} as the backing file. This is robust
+     * for merged segments, whose per-leaf {@code writer_generation} attribute is reset to 0.
+     *
+     * <p>Best-effort: any leaf that cannot be resolved (no catalog match, or no Parquet file in the
+     * matched segment) is left unstamped; the codec then simply serves no Parquet doc values for it
+     * rather than reading the wrong file.
+     */
+    private void stampParquetDocValuesFiles(DirectoryReader directoryReader, CatalogSnapshot catalogSnapshot) {
+        if (catalogSnapshot == null) {
+            return;
+        }
+        // Build: lucene-file-set -> absolute parquet file path, from the catalog snapshot.
+        Map<Set<String>, String> luceneFilesToParquetPath = new HashMap<>();
+        for (Segment segment : catalogSnapshot.getSegments()) {
+            WriterFileSet luceneWfs = segment.dfGroupedSearchableFiles().get("lucene");
+            WriterFileSet parquetWfs = segment.dfGroupedSearchableFiles().get("parquet");
+            if (luceneWfs == null || parquetWfs == null || parquetWfs.files().isEmpty()) {
+                continue;
+            }
+            String parquetFileName = parquetWfs.files().iterator().next();
+            String parquetPath = java.nio.file.Path.of(parquetWfs.directory(), parquetFileName).toString();
+            luceneFilesToParquetPath.put(luceneWfs.files(), parquetPath);
+        }
+        if (luceneFilesToParquetPath.isEmpty()) {
+            return;
+        }
+        for (org.apache.lucene.index.LeafReaderContext lrc : directoryReader.leaves()) {
+            try {
+                org.apache.lucene.index.SegmentReader sr = Lucene.segmentReader(lrc.reader());
+                Set<String> leafFiles = new HashSet<>(sr.getSegmentInfo().files());
+                String parquetPath = luceneFilesToParquetPath.get(leafFiles);
+                if (parquetPath != null) {
+                    sr.getSegmentInfo().info.putAttribute(PARQUET_DOCVALUES_FILE_ATTRIBUTE, parquetPath);
+                }
+                // A leaf with no catalog match is left unstamped (best-effort): the codec then
+                // serves no Parquet doc values for it rather than reading the wrong file.
+            } catch (IOException | RuntimeException ignored) {
+                // Best-effort binding: a leaf that cannot be resolved is left unstamped.
+            }
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/exec/Indexer.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/Indexer.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.IndexCommit;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.concurrent.GatedCloseable;
+import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.engine.EngineConfig;
 import org.opensearch.index.engine.EngineException;
@@ -24,6 +25,7 @@ import org.opensearch.index.translog.TranslogManager;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Unified interface for indexing operations in OpenSearch.
@@ -82,6 +84,57 @@ public interface Indexer
      */
     default boolean isReplicaIndexer() {
         return false;
+    }
+
+    /**
+     * Acquires a point-in-time {@link Engine.SearcherSupplier} that can be used to create
+     * {@link Engine.Searcher}s on demand. This lets a format-aware indexer (one that has no inner
+     * {@link org.opensearch.index.engine.Engine}) expose a Lucene searcher built from its own
+     * {@link IndexReaderProvider.Reader}, so the standard {@code _search} path can reach it without
+     * {@link org.opensearch.index.shard.IndexShard} ever depending on the concrete engine type.
+     * <p>
+     * The default implementation throws {@link UnsupportedOperationException}; indexers that are
+     * backed by a legacy {@link org.opensearch.index.engine.Engine} are handled by the caller via
+     * {@link org.opensearch.index.engine.EngineBackedIndexer} and never reach this method.
+     *
+     * @param wrapper a function applied to each acquired {@link Engine.Searcher} (e.g. reader wrapping)
+     * @param scope   the searcher scope
+     * @return a searcher supplier whose {@code close()} releases the underlying reader resources
+     */
+    default Engine.SearcherSupplier acquireSearcherSupplier(Function<Engine.Searcher, Engine.Searcher> wrapper, Engine.SearcherScope scope) {
+        throw new UnsupportedOperationException("acquireSearcherSupplier not supported by " + getClass().getName());
+    }
+
+    /**
+     * Acquires a single {@link Engine.Searcher} for the given source. The default implementation
+     * delegates to {@link #acquireSearcherSupplier(Function, Engine.SearcherScope)} and acquires a
+     * searcher from the returned supplier, mirroring the legacy
+     * {@link org.opensearch.index.engine.Engine#acquireSearcher(String, Engine.SearcherScope, Function)}
+     * convenience. Indexers backed by a legacy engine are handled by the caller and never reach this method.
+     *
+     * @param source  description of why the searcher is being acquired
+     * @param scope   the searcher scope
+     * @param wrapper a function applied to the acquired {@link Engine.Searcher}
+     * @return a searcher whose {@code close()} releases the supplier and the underlying reader resources
+     */
+    default Engine.Searcher acquireSearcher(String source, Engine.SearcherScope scope, Function<Engine.Searcher, Engine.Searcher> wrapper) {
+        Engine.SearcherSupplier supplier = acquireSearcherSupplier(wrapper, scope);
+        try {
+            Engine.Searcher searcher = supplier.acquireSearcher(source);
+            final Engine.SearcherSupplier toClose = supplier;
+            Engine.Searcher wrapped = new Engine.Searcher(
+                searcher.source(),
+                searcher.getDirectoryReader(),
+                searcher.getSimilarity(),
+                searcher.getQueryCache(),
+                searcher.getQueryCachingPolicy(),
+                () -> IOUtils.close(searcher, toClose)
+            );
+            supplier = null; // ownership transferred to the returned searcher
+            return wrapped;
+        } finally {
+            IOUtils.closeWhileHandlingException(supplier);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/engine/exec/SearchableDirectoryReaderProvider.java
+++ b/server/src/main/java/org/opensearch/index/engine/exec/SearchableDirectoryReaderProvider.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine.exec;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.opensearch.common.annotation.ExperimentalApi;
+
+/**
+ * Marker interface for format-specific reader objects that can provide a Lucene
+ * {@link DirectoryReader} for search operations. Implementations live in format plugins
+ * (e.g. the Lucene backend plugin's {@code LuceneReader}), while this interface lives in
+ * the server module so that {@code DataFormatAwareEngine} can obtain a {@link DirectoryReader}
+ * without depending on any specific format plugin at compile time.
+ *
+ * @opensearch.experimental
+ */
+@ExperimentalApi
+public interface SearchableDirectoryReaderProvider {
+
+    /**
+     * Returns the {@link DirectoryReader} that can be used to build an
+     * {@link org.opensearch.index.engine.Engine.Searcher} for the standard search path.
+     *
+     * @return a non-null directory reader
+     */
+    DirectoryReader directoryReader();
+}

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -2475,8 +2475,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     public Engine.SearcherSupplier acquireSearcherSupplier(Engine.SearcherScope scope) {
         readAllowed();
         markSearcherAccessed();
-        final Indexer engine = getIndexer();
-        return applyOnEngine(engine, eng -> eng.acquireSearcherSupplier(this::wrapSearcher, scope));
+        final Indexer indexer = getIndexer();
+        if (indexer instanceof EngineBackedIndexer engineBacked) {
+            // Legacy Lucene-backed engine path — unchanged.
+            return engineBacked.getEngine().acquireSearcherSupplier(this::wrapSearcher, scope);
+        }
+        // Format-aware indexer (e.g. composite engine) that exposes a searcher built from its
+        // own IndexReaderProvider.Reader. IndexShard never references the concrete engine type.
+        return indexer.acquireSearcherSupplier(this::wrapSearcher, scope);
     }
 
     public Engine.Searcher acquireSearcher(String source) {
@@ -2494,7 +2500,26 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         readAllowed();
         markSearcherAccessed();
         final Indexer indexer = getIndexer();
-        return applyOnEngine(indexer, engine -> engine.acquireSearcher(source, scope, this::wrapSearcher));
+        if (indexer instanceof EngineBackedIndexer engineBacked) {
+            // Legacy Lucene-backed engine path — unchanged.
+            return engineBacked.getEngine().acquireSearcher(source, scope, this::wrapSearcher);
+        }
+        // Format-aware indexer (e.g. composite engine). IndexShard never references the concrete engine type.
+        return indexer.acquireSearcher(source, scope, this::wrapSearcher);
+    }
+
+    /**
+     * Acquires a searcher without going through {@link #wrapSearcher}. Used by internal
+     * refresh listeners (e.g. lucene_field_count) that need the raw reader without
+     * derived-source wrapping. Branches on indexer type the same way as
+     * {@link #acquireSearcher(String, Engine.SearcherScope)}.
+     */
+    private Engine.Searcher acquireSearcherDirect(String source, Engine.SearcherScope scope) {
+        final Indexer indexer = getIndexer();
+        if (indexer instanceof EngineBackedIndexer engineBacked) {
+            return engineBacked.getEngine().acquireSearcher(source, scope);
+        }
+        return indexer.acquireSearcher(source, scope, Function.identity());
     }
 
     /**
@@ -4664,10 +4689,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                     // Use the engine directly (not IndexShard.acquireSearcher) so that we do NOT
                     // go through IndexShard.wrapSearcher.
                     try (
-                        Engine.Searcher searcher = applyOnEngine(
-                            getIndexer(),
-                            engine -> engine.acquireSearcher("lucene_field_count", Engine.SearcherScope.INTERNAL)
-                        )
+                        Engine.Searcher searcher = acquireSearcherDirect("lucene_field_count", Engine.SearcherScope.INTERNAL)
                     ) {
                         FieldInfos fieldInfos = FieldInfos.getMergedFieldInfos(searcher.getIndexReader());
                         mapperService.getLuceneFieldTracker().setFieldInfos(fieldInfos);


### PR DESCRIPTION
This branch is Manas's Parquet DocValues codec work (3 layer-commits) plus a decode-performance commit on top.

## Layers (review bottom-up)

1. **`e33e83e` Parquet DocValues codec** — a read-only Lucene `DocValuesFormat` that serves doc values from the segment's Parquet file over FFM. `ParquetDocValuesLeafReader` synthesizes `FieldInfo`s for Parquet-only fields and serves all five DV types from a per-segment `ParquetDocValuesProducer`; per-query page cache; row-id story (merges initially broke rowId==docId, then the write path was fixed to guarantee it).
2. **`88821bc` Liquid cache integration** — the DataFusion-side liquid POC + a codec-side cross-query decoded-page cache built on liquid-cache core.
3. **`1ac7010` Zero-copy reads** — identity row-id remap skip + off-heap `MemorySegment` page reads.
4. **`d0d344f` Speed up codec decode by 17–38%** — the optimization commit (details below).

## Optimization commit (`d0d344f`)

Three decode-path changes plus per-segment wrap-plan caching:

- **Per-handle locking** — the native column-reader registry moves from a single global mutex held across whole decodes to a per-handle lock (registry lock only to clone the handle `Arc`). Concurrent queries and the prefetch below no longer serialize process-wide.
- **arrow-rs RowSelection decode** — replaces the low-level `get_column_reader` + `skip_records` + `read_records` loop with `ParquetRecordBatchReaderBuilder` driven by a `RowSelection` `[skip(page_start), select(page_rows), skip(rest)]` + single-leaf `ProjectionMask`. `ArrowReaderMetadata` is cached at column open (no per-decode footer re-read); the leading skip seeks via the offset index instead of walking pages.
- **Page prefetch** — on sequential scans, decode page N+1 on a background daemon thread while the query thread consumes page N; adopt on the next miss with zero FFM. The prefetch thread uses its **own** `BufferPool` (the pool's map/Arena are not thread-safe), and the adopted page's value segment lives in a shared `Arena` read-only after decode. Sequential detection gates engagement; `close()` joins any in-flight prefetch.
- **Wrap-plan cache + trusted row count** — cache the reader wrap plan (FieldInfo synthesis + Parquet-file resolution) per segment core cache key; trust the writer's `numRows == maxDoc` invariant instead of re-reading the footer per producer (kept behind an `-ea` assert).

## Benchmark

ClickBench, **99,997,497 docs**, single shard, warm (median of 5), release build (`lto=true`), `search.concurrent_segment_search.mode=none`, request/query cache off. A/B on the same node/data, one variant live at a time, engine confirmed live via `java.library.path`. **Results are byte-identical and deterministic across all 5 runs on both arms** — `avg_Age=25.464076815842702`, `sum_UserID=2.52888973009538e26`, `terms` top bucket `229`.

| Query | Baseline codec | Optimized | Speedup |
|---|---|---|---|
| `sum(UserID)` | 2306 ms | **1743 ms** | 1.32× |
| `avg(Age)` | 1264 ms | **918 ms** | 1.38× |
| `terms(RegionID, size=1000)` | 2875 ms | **2456 ms** | 1.17× |

The wins come from the vectorized arrow-rs decode plus prefetch overlap on the dense scan path.

### Exact query bodies (POST `/clickbench/_search`)
```json
{"size":0,"track_total_hits":true,"query":{"match_all":{}},"aggs":{"a":{"sum":{"field":"UserID"}}}}
{"size":0,"track_total_hits":true,"query":{"match_all":{}},"aggs":{"by_region":{"terms":{"field":"RegionID","size":1000}}}}
{"size":0,"track_total_hits":true,"query":{"match_all":{}},"aggs":{"a":{"avg":{"field":"Age"}}}}
```

## Correctness note

The prefetch initially shipped a data race that passed all 241 module unit tests but produced non-deterministic aggregate *values* (correct row count, drifting sums) — caught only by capturing result values in the A/B. Root cause was `BufferPool`'s unsynchronized map/Arena being touched by both threads; the fix is the dedicated per-thread pool described above. All 241 module tests pass; A/B values are deterministic.

## Not in this PR (next step)

Candidate-bitmap `RowSelection` from the search path — feed matched docIds as a `RowSelection` so sparse filtered aggregations decode only matched rows instead of whole pages (the ~60× gap on selective filters). Design agreed (pre-scan scorer → `FixedBitSet` → leaf reader), not yet implemented.
